### PR TITLE
feat(client): search debounce helpers, min-length filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,9 @@ server/Api/wwwroot/**
 **/appsettings.*.json
 
 client/graphify-out/
-client/.cursor/
+
+# Cursor workspace: keep rules and index versioned; omit local context clones
+client/.cursor/context/
 
 #moat
 client/.moat/

--- a/client/.cursor/README.md
+++ b/client/.cursor/README.md
@@ -1,0 +1,20 @@
+## Client Cursor workspace
+
+### Canonical architecture (repo)
+
+**Primary documentation:** [`../architect/`](../architect/) — `README.md`, `ARCHITECTURE.md`, `SYSTEM_MAP.md`, `MODULES.md`, `GRAPH_OVERVIEW.md`.
+
+Update those files when the app structure or API strategy changes; then sync summaries under `context/` if needed.
+
+### This folder (`.cursor/`)
+
+| Path | Role |
+|------|------|
+| `rules/` | Cursor rules (`*.mdc`): graphify, architecture, debounce/search, **git branch & commit**. |
+| `context/architecture/` | Short entry + **links** to `client/architect/*` (avoid long drift from canonical). |
+| `context/graphify/` | Quick graph summary; align with `client/graphify-out/` and `architect/GRAPH_OVERVIEW.md`. |
+
+### Data sources
+
+- **Graphify artifacts:** `client/graphify-out/` (gitignored). Regenerate after large refactors.
+- **Stack / routes / modules:** `client/architect/`.

--- a/client/.cursor/rules/architect.mdc
+++ b/client/.cursor/rules/architect.mdc
@@ -1,0 +1,18 @@
+---
+description: Use client/architect for full architecture before large refactors or new modules.
+alwaysApply: true
+---
+
+# Architecture source of truth
+
+For **blocks-idp** SPA structure, API conventions, routes, and module boundaries:
+
+1. Read **`client/architect/README.md`** for the index.
+2. Use **`client/architect/ARCHITECTURE.md`** for layers, auth, and HTTP.
+3. Use **`client/architect/SYSTEM_MAP.md`** for directories and route groups.
+4. Use **`client/architect/MODULES.md`** for `@blocks-*` aliases and service patterns.
+5. Use **`client/architect/GRAPH_OVERVIEW.md`** (and `client/graphify-out/GRAPH_REPORT.md` if present) for dependency graph hubs and communities.
+
+**API:** All `API_BASES` in `client/app/constants/endpoint.constant.ts` use the `/api` prefix; do not reintroduce per-service URL roots like `/idp/v1` in client path constants without an explicit product decision.
+
+**Cursor mirror:** `client/.cursor/context/architecture/README.md` links to the same docs—prefer editing `client/architect/` first.

--- a/client/.cursor/rules/debounce-search.mdc
+++ b/client/.cursor/rules/debounce-search.mdc
@@ -1,0 +1,32 @@
+---
+description: Debounce and search-query standards—use @/lib/utils and single responsibility per layer; align with Graphify cross-cutting hubs.
+alwaysApply: true
+---
+
+# Debounce and search input (client)
+
+Canonical implementation lives in **`client/app/lib/utils.ts`**: `debounce`, `normalizeSearchQueryText`, `debounceSearchQuery`, and `DebouncedFunction` / `DebouncedSearchQuery` types. These utilities are **graph hubs**—when tracing list filtering or HTTP timing, start from `utils.ts` and **`client/architect/GRAPH_OVERVIEW.md`** / `client/graphify-out/GRAPH_REPORT.md` (if present).
+
+## Debounce
+
+1. **Use only** `debounce` from `@/lib/utils`—do not hand-roll `setTimeout` debouncing for the same purpose.
+2. **Default delay** is **300ms** unless product explicitly requires another value; keep one constant per feature if you need to document it.
+3. **Always** register cleanup: `useEffect(() => () => debounced.cancel(), [debounced]);` (or equivalent) so pending timers do not fire after unmount.
+4. **`cancel()`** clears the scheduled call; use it on **reset**, **clear search**, or navigation so stale updates do not hit URL/state/API.
+5. **`flush()`** runs the pending invocation immediately—use sparingly (e.g. “commit now” before submit), not for ordinary typing.
+6. **One debounce layer per user path**: filter `SearchInput` / `DropdownSearchInput` already debounce `onChange`. Do **not** add a second debounce in a parent for the same keystream without disabling the inner delay (double delay and harder debugging). Prefer adjusting a single layer.
+
+## Search text and API calls (minimum length)
+
+1. **Normalize** free-text search before it affects the backend: `normalizeSearchQueryText(raw, minLength?)` — default `minLength` is **3**; returns `""` for shorter or whitespace-only input after `trim`.
+2. Apply normalization in **data hooks** that build list payloads (e.g. `useGetUsers` normalizes `filter.email` / `filter.name`), so **every** caller gets the same contract. Pages may keep URL/query showing the raw draft; React Query `queryKey` should use the **normalized** payload where it drives the request.
+3. For list hooks that take a single `search` string, pass `search: normalizeSearchQueryText(queryParams.search)` into the hook options (or normalize inside that hook)—do not duplicate ad-hoc `(trim.length >= 3)` scattered in components.
+4. **`debounceSearchQuery`** wraps debounce + `normalizeSearchQueryText` end-to-end for **string** callbacks when you own the only debounce layer (e.g. custom control). Do not bolt min-length behavior into generic `debounce`; other call sites depend on arbitrary argument types.
+
+## UI / copy
+
+5. Prefer **short placeholders** (“Minimum 3 characters…”) and optional **feature-local** hints (paragraph above toolbar) rather than stuffing long explanations into shared `filter-toolbar` primitives. **`DropdownSearchInput` / `SearchInput`** stay reusable; wording lives with the route/module.
+
+## Verification
+
+6. After changes to debounce or search normalization, run **`npm run type-check`** under **`client/`** and manually verify Network: short strings must not carry search filters to `/api/` when normalization returns empty.

--- a/client/.cursor/rules/git-branch-commit.mdc
+++ b/client/.cursor/rules/git-branch-commit.mdc
@@ -1,0 +1,40 @@
+---
+description: Branch and commit workflow for client work—branch from dev, Conventional Commits, scoped messages.
+alwaysApply: true
+---
+
+# Git: branch and commits (client SPA)
+
+When you start a **focused change** (feature, fix, or chore) that the user wants on a **dedicated branch with a commit**:
+
+## Branching
+
+1. **Base:** create the branch from **`dev`** (prefer `git fetch origin dev` first if collaborating on remotes).
+2. **Naming:** use **kebab-case**, short and **scope-prefixed**:
+   - `feat/<topic>` — behavior users see (e.g. `feat/idp-search-debounce-min-length`)
+   - `fix/<topic>` — bugs or regressions (e.g. `fix/users-filter-query-key`)
+   - `chore/<topic>` — tooling, deps, formatting (e.g. `chore/client-vite-config`)
+3. **One concern per branch** when possible; split unrelated work into separate branches/PRs.
+
+## Commits
+
+4. **Subject line:** imperative mood, **~72 characters**, no trailing period unless part of an identifier.
+   - Prefer [**Conventional Commits**](https://www.conventionalcommits.org/): `type(scope): summary`
+   - Common **types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`.
+   - **Optional scope:** client area, e.g. `feat(iam-users): …`, `fix(filter-toolbar): …`.
+5. **Body (optional):** wrap at ~72 chars; explain **why** if the diff is not obvious; reference issues/tickets if used by the team.
+6. **Do not** lump unrelated file groups into one commit unless the user explicitly asks for a single squash; prefer **logical commits** (e.g. lib util + hook + UI) that still tell one story.
+
+## Flow (typical)
+
+```bash
+git checkout dev && git pull origin dev   # if using shared remote
+git checkout -b feat/your-topic-name
+# … changes …
+git add -p   # or paths
+git commit -m "feat(iam): add search min-length normalization in useGetUsers"
+```
+
+## With Cursor rules
+
+7. If the user says **“branch and commit”** (or equivalent), follow this rule **after** implementing: create branch from `dev`, stage only relevant paths, write message per above, and **do not** push unless they ask (push may need network and review).

--- a/client/.cursor/rules/graphify.mdc
+++ b/client/.cursor/rules/graphify.mdc
@@ -1,0 +1,24 @@
+---
+description: Use Graphify graph artifacts alongside client/architect for relationship questions.
+alwaysApply: true
+---
+Use the Graphify outputs to answer architecture and code-relationship questions with better context. Pair them with **`client/architect/ARCHITECTURE.md`** and **`client/architect/GRAPH_OVERVIEW.md`** for intent and scale.
+
+## Primary sources (client root)
+
+- `client/graphify-out/GRAPH_REPORT.md`
+- `client/graphify-out/graph.json`
+- `client/graphify-out/graph.html`
+- `client/graphify-out/needs_update` (if present)
+
+## Cursor-local context
+
+- `client/.cursor/context/graphify/README.md`
+- `client/.cursor/context/graphify/GRAPHIFY_SUMMARY.md` (abridged; sync with `client/architect/GRAPH_OVERVIEW.md`)
+
+## Working rules
+
+- For relationship maps, read `client/graphify-out/GRAPH_REPORT.md` when it exists (regenerate if stale).
+- Use **`client/architect/GRAPH_OVERVIEW.md`** for a maintained summary of hubs/communities and graph scale.
+- Prefer Graphify "god nodes" and community clusters when choosing where to inspect code; **validate inferred edges** in source.
+- After significant code edits, run your Graphify refresh (e.g. `graphify update .` in `client/`).

--- a/client/app/idp/iam/hooks/use-user.ts
+++ b/client/app/idp/iam/hooks/use-user.ts
@@ -6,13 +6,42 @@ import {
   IGetSignUpSettingPayload,
 } from "@blocks-idp/iam/models/user";
 import { userService } from "@blocks-idp/iam/services/user.service";
+import { normalizeSearchQueryText } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 
 export const useGetUsers = (option: IGetUsersPayload) => {
+  const { page, pageSize, projectKey, filter, sort } = option;
+
+  const payload = useMemo((): IGetUsersPayload => {
+    if (!filter) {
+      return { page, pageSize, projectKey, sort };
+    }
+    return {
+      page,
+      pageSize,
+      projectKey,
+      sort,
+      filter: {
+        ...filter,
+        email: normalizeSearchQueryText(filter.email ?? ""),
+        name: normalizeSearchQueryText(filter.name ?? ""),
+      },
+    };
+  }, [
+    page,
+    pageSize,
+    projectKey,
+    filter?.email,
+    filter?.name,
+    filter?.organizationId,
+    sort?.property,
+    sort?.isDescending,
+  ]);
+
   return useQuery({
-    queryKey: ["users", option],
-    queryFn: () => userService.getUsers(option),
+    queryKey: ["users", payload],
+    queryFn: () => userService.getUsers(payload),
   });
 };
 

--- a/client/app/idp/iam/modules/organization-management/organizations/organizations-filter-toolbar.tsx
+++ b/client/app/idp/iam/modules/organization-management/organizations/organizations-filter-toolbar.tsx
@@ -1,8 +1,7 @@
-
-
 import { FilterToolbar, useSortQueryParams } from "@/components/filter-toolbar";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 
+/** nuqs state: search text, pagination (page is reset when filters change). */
 export const useOrganizationsFilterQueryParams = () => {
   const [queryParams, setQueryParams] = useQueryStates({
     search: parseAsString.withDefault(""),
@@ -15,6 +14,17 @@ export const useOrganizationsFilterQueryParams = () => {
 export const useOrganizationsSortQueryParams = () =>
   useSortQueryParams({ initial: { property: "Name", isDescending: false } });
 
+const SEARCH_FILTER = {
+  key: "search" as const,
+  type: "SearchInput" as const,
+  label: "Organization search",
+  props: {
+    placeholder: "Search by name (minimum 3 characters)",
+    className: "min-w-[17rem] md:min-w-[20rem]",
+  },
+};
+
+/** URL filters for the organizations table; search debounce lives in the shared SearchInput. */
 export function OrganizationsFilterToolbar() {
   const { queryParams, setQueryParams } = useOrganizationsFilterQueryParams();
 
@@ -30,7 +40,7 @@ export function OrganizationsFilterToolbar() {
 
   return (
     <FilterToolbar
-      filters={[{ key: "search", type: "SearchInput", label: "label" }]}
+      filters={[SEARCH_FILTER]}
       values={{
         search: queryParams.search,
       }}

--- a/client/app/idp/iam/modules/organization-management/organizations/organizations.tsx
+++ b/client/app/idp/iam/modules/organization-management/organizations/organizations.tsx
@@ -1,7 +1,6 @@
-
-
 import { Card, CardContent, CardHeader } from "@/components/ui-kits/card/card";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
+import { normalizeSearchQueryText } from "@/lib/utils";
 import { useGetOrganizations, useGetOrganizationConfig } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@/store/useProjectStore";
 import { OrganizationsList } from "./organizations-list";
@@ -16,8 +15,10 @@ export function Organizations() {
   const { tenantId } = useProjectStore().selectedProject || { tenantId: "" };
   const { queryParams, setQueryParams } = useOrganizationsFilterQueryParams();
   const { sortQueryParams } = useOrganizationsSortQueryParams();
+  const effectiveSearch = normalizeSearchQueryText(queryParams.search);
   const { isLoading, isFetching, data } = useGetOrganizations({
     ...queryParams,
+    search: effectiveSearch,
     sort: sortQueryParams,
     projectKey: tenantId,
   });

--- a/client/app/idp/iam/modules/user-management/users/users-filter-toolbar.tsx
+++ b/client/app/idp/iam/modules/user-management/users/users-filter-toolbar.tsx
@@ -50,33 +50,35 @@ export const UsersFilterToolbar = () => {
 
   return (
     <FilterToolbar<UsersFilter>
-      filters={[
-        {
-          key: "search",
-          type: "DropdownSearchInput",
-          label: "",
-          props: {
-            className: {
-              selectContent: "min-w-fit",
-              SelectItem: "[&>*:first-child]:hidden flex justify-center px-2",
+        filters={[
+          {
+            key: "search",
+            type: "DropdownSearchInput",
+            label: "User search",
+            props: {
+              placeholder: "Minimum 3 characters…",
+              className: {
+                selectContent: "min-w-fit",
+                SelectItem: "[&>*:first-child]:hidden flex justify-center px-2",
+                input: "min-w-[17rem] md:min-w-[20rem]",
+              },
+              options: [
+                { label: <Mail className="aspect-square w-4" />, value: "email" },
+                { label: <User className="aspect-square w-4" />, value: "name" },
+              ],
             },
-            options: [
-              { label: <Mail className="aspect-square w-4" />, value: "email" },
-              { label: <User className="aspect-square w-4" />, value: "name" },
-            ],
           },
-        },
-      ]}
-      values={{
-        search: {
-          selected: queryParams["selected-filter"],
-          value: queryParams["selected-filter"] === "email" ? queryParams.email : queryParams.name,
-        },
-      }}
-      defaultValues={{ search: { selected: "name", value: "" } }}
-      onChange={changeHandler}
-      onReset={resetHandler}
-      hideGlobalResetButton
-    />
+        ]}
+        values={{
+          search: {
+            selected: queryParams["selected-filter"],
+            value: queryParams["selected-filter"] === "email" ? queryParams.email : queryParams.name,
+          },
+        }}
+        defaultValues={{ search: { selected: "name", value: "" } }}
+        onChange={changeHandler}
+        onReset={resetHandler}
+        hideGlobalResetButton
+      />
   );
 };

--- a/client/app/idp/iam/modules/user-management/users/users.tsx
+++ b/client/app/idp/iam/modules/user-management/users/users.tsx
@@ -18,7 +18,10 @@ export const Users = () => {
     page: queryParams.page,
     pageSize: queryParams.pageSize,
     projectKey: tenantId,
-    filter: { email: queryParams.email, name: queryParams.name },
+    filter: {
+      email: queryParams.email,
+      name: queryParams.name,
+    },
     sort: sortQueryParams,
   });
 

--- a/client/app/lib/utils.ts
+++ b/client/app/lib/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { isValid as isValidDate, isBefore } from "date-fns";
@@ -43,22 +42,74 @@ export function clearBreadCrumbTitleEntry(pathName: string) {
   BREADCRUMB_CUSTOM_TITLES[pathName] = null;
 }
 
-export const debounce = (fn: Function, ms = 300) => {
-  let timeoutId: ReturnType<typeof setTimeout> | null;
-  const debounced = function (this: unknown, ...args: unknown[]) {
-    if (timeoutId) clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+// -----------------------------------------------------------------------------
+// Debounce & search-query helpers (generic debounce; optional min-length for API)
+// -----------------------------------------------------------------------------
+
+export type DebouncedFunction<T extends (...args: never[]) => void> = T & {
+  cancel: () => void;
+  /** If a call is scheduled, invoke the callback now with the latest arguments and clear the timer. */
+  flush: () => void;
+};
+
+export function debounce<T extends (...args: never[]) => void>(fn: T, ms = 300): DebouncedFunction<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let lastThis: unknown;
+  let lastArgs: Parameters<T> | null = null;
+
+  const flushPending = () => {
+    if (lastArgs === null) return;
+    const args = lastArgs;
+    lastArgs = null;
+    fn.apply(lastThis, args);
   };
+
+  const debounced = function (this: unknown, ...args: Parameters<T>) {
+    lastThis = this;
+    lastArgs = args;
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
+      flushPending();
+    }, ms);
+  } as DebouncedFunction<T>;
 
   debounced.cancel = () => {
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = null;
     }
+    lastArgs = null;
+  };
+
+  debounced.flush = () => {
+    if (timeoutId === null || lastArgs === null) return;
+    clearTimeout(timeoutId);
+    timeoutId = null;
+    flushPending();
   };
 
   return debounced;
-};
+}
+
+/** Trims; returns `""` unless length is at least `minLength` (default 3). */
+export function normalizeSearchQueryText(raw: string, minLength = 3): string {
+  const t = raw.trim();
+  return t.length >= minLength ? t : "";
+}
+
+export type DebouncedSearchQuery = DebouncedFunction<(rawSearch: string) => void>;
+
+/** Debounces raw input, then passes the result of {@link normalizeSearchQueryText} to `onChange`. */
+export function debounceSearchQuery(
+  onChange: (effective: string) => void,
+  ms = 300,
+  minLength = 3,
+): DebouncedSearchQuery {
+  return debounce((rawSearch: string) => {
+    onChange(normalizeSearchQueryText(rawSearch, minLength));
+  }, ms);
+}
 
 export const parseMongoDBString = (text: string) => {
   return text


### PR DESCRIPTION
Add typed debounce with cancel/flush, normalizeSearchQueryText, and debounceSearchQuery in lib/utils. Normalize user filters inside useGetUsers before the API; organizations pass normalized search to useGetOrganizations.

Update IAM users/organizations filter toolbars and placeholders. Version client/.cursor rules (debounce, git workflow) and ignore only .cursor/context.
