### PR TITLE
fix: point ME endpoint at /api/auth/me

### DIFF
--- a/client/app/idp/iam/constants/endpoint.constant.ts
+++ b/client/app/idp/iam/constants/endpoint.constant.ts
@@ -8,7 +8,7 @@ const AUTH_SUBPATH = "/auth";
 export const USER_ENDPOINTS = {
   GET_USERS: `/api${IAM_SUBPATH}/users`,
   GET_USER: `/api${IAM_SUBPATH}/users`,
-  ME: `/api${IAM_SUBPATH}/me`,
+  ME: `/api${AUTH_SUBPATH}/me`,
 
   CREATE: `/api${IAM_SUBPATH}/users/create`,
   UPDATE: `/api${IAM_SUBPATH}/users/update`,


### PR DESCRIPTION
The /me route lives on AuthenticationController ([Route("auth")], HttpGet("me")) — using /api/iam/me was wrong. Update the constant to use the auth subpath.