### PR TITLE
fix: treat empty /api/auth/me data as user not found

### DIFF
--- a/client/app/guards/protected-guard.tsx
+++ b/client/app/guards/protected-guard.tsx
@@ -16,16 +16,16 @@ import LogoLoadingSpinner from "@/components/loader-spinner/loader-spinner";
 
 export function ProtectedGuard({ children }: { children: React.ReactNode }) {
   const { isMounted } = useAppState();
-  const { data } = useGetMe();
+  const { data, userFound } = useGetMe();
   const { setUser } = useAuthStore();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!isMounted) return;
-    if (!data) return navigate(`/login`, { replace: true });
+    if (!data || !userFound) return navigate(`/login`, { replace: true });
     // setUser(data.data);
-  }, [data, navigate, setUser]);
-  if (!isMounted || !data) return null;
+  }, [data, userFound, navigate, setUser]);
+  if (!isMounted || !data || !userFound) return null;
   return <>{children}</>;
 }
 

--- a/client/app/idp/iam/constants/endpoint.constant.ts
+++ b/client/app/idp/iam/constants/endpoint.constant.ts
@@ -8,7 +8,7 @@ const AUTH_SUBPATH = "/auth";
 export const USER_ENDPOINTS = {
   GET_USERS: `/api${IAM_SUBPATH}/users`,
   GET_USER: `/api${IAM_SUBPATH}/users`,
-  ME: `/api${AUTH_SUBPATH}/me`,
+  ME: `/api${IAM_SUBPATH}/me`,
 
   CREATE: `/api${IAM_SUBPATH}/users/create`,
   UPDATE: `/api${IAM_SUBPATH}/users/update`,

--- a/client/app/idp/iam/hooks/use-user.ts
+++ b/client/app/idp/iam/hooks/use-user.ts
@@ -60,7 +60,7 @@ export const useGetUser = (options?: { enabled?: boolean }) => {
 
 export const useGetMe = (options?: { enabled?: boolean }) => {
   // const authStore = useAuthStore();
-  return useQuery({
+  const query = useQuery({
     queryKey: ["user"],
     queryFn: async () => {
       const user = await userService.me();
@@ -71,6 +71,14 @@ export const useGetMe = (options?: { enabled?: boolean }) => {
     staleTime: Infinity,
     ...options,
   });
+
+  const userFound =
+    query.data?.data != null && Object.keys(query.data.data).length > 0;
+
+  return {
+    ...query,
+    userFound,
+  };
 };
 
 export const useGetUserById = (


### PR DESCRIPTION
When the /me endpoint returns { data: {}, errors: null }, treat that as "user not found" instead of a successful empty payload. useGetMe now exposes a `userFound` boolean derived from the response, and ProtectedGuard redirects to /login when userFound is false.