### PR TITLE
refactor(authentication-domain): Phase 1 SonarQube quick wins 

### DIFF
--- a/server/Authentication.DomainService/Authentication/AuthenticationConfigurationService.cs
+++ b/server/Authentication.DomainService/Authentication/AuthenticationConfigurationService.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class AuthenticationConfigurationService : IAuthenticationConfigurationService
+    public sealed class AuthenticationConfigurationService : IAuthenticationConfigurationService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly ITenants _tenants;

--- a/server/Authentication.DomainService/Authentication/AuthenticationFlowService.cs
+++ b/server/Authentication.DomainService/Authentication/AuthenticationFlowService.cs
@@ -21,7 +21,7 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class AuthenticationFlowService : IAuthenticationFlowService
+    public sealed class AuthenticationFlowService : IAuthenticationFlowService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly ITenants _tenants;
@@ -694,7 +694,14 @@ namespace Authentication.DomainService.Authentication
             await _authenticationRepository.RevokeIdentitySessionsByRefreshTokensAsync(new List<string> { refreshToken });
 
             await _cacheClient.RemoveKeyAsync(refreshToken);
-            _logger.LogWarning("Potential refresh token reuse detected for token {RefreshToken}. Existing session revoked.", refreshToken);
+            var tokenFingerprint = TruncateToken(refreshToken);
+            _logger.LogWarning("Potential refresh token reuse detected for token {TokenFingerprint}. Existing session revoked.", tokenFingerprint);
+        }
+
+        private static string TruncateToken(string token)
+        {
+            const int visibleLength = 8;
+            return token.Length <= visibleLength ? token : string.Concat(token.AsSpan(0, visibleLength), "...");
         }
 
         private static string? ResolveClientId(HttpRequest request, string? modelClientId = null)

--- a/server/Authentication.DomainService/Authentication/AuthenticationService.cs
+++ b/server/Authentication.DomainService/Authentication/AuthenticationService.cs
@@ -26,7 +26,7 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class AuthenticationService : IAuthenticationService
+    public sealed class AuthenticationService : IAuthenticationService
     {
         private static readonly HttpClient BackchannelHttpClient = new();
         private readonly ILogger<AuthenticationService> _logger;
@@ -42,7 +42,7 @@ namespace Authentication.DomainService.Authentication
         private readonly UnifiedTokenSessionService _unifiedTokenSessionService;
         private readonly IOAuthJwtAccessTokenManager _oAuthJwtAccessTokenManager;
 
-        private const string Public_Cert_Cache_Prefix = "tetocertpublic::";
+        private const string PublicCertCachePrefix = "tetocertpublic::";
 
         public AuthenticationService(
             ILogger<AuthenticationService> logger,
@@ -631,7 +631,7 @@ namespace Authentication.DomainService.Authentication
             if (!string.IsNullOrEmpty(token))
             {
                 var tokenHandler = new JwtSecurityTokenHandler();
-                string cacheKey = $"{Public_Cert_Cache_Prefix}{tenant.TenantId}";
+                string cacheKey = $"{PublicCertCachePrefix}{tenant.TenantId}";
                 var certificateData = await _cacheClient.CacheDatabase().StringGetAsync(cacheKey);
                 var validationParams = tenant.JwtTokenParameters;
                 var publicCert = X509CertificateLoader.LoadPkcs12(certificateData, validationParams.PublicCertificatePassword);

--- a/server/Authentication.DomainService/Authentication/AuthorizationFlowService.cs
+++ b/server/Authentication.DomainService/Authentication/AuthorizationFlowService.cs
@@ -31,7 +31,7 @@ using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class AuthorizationFlowService : IAuthorizationFlowService
+    public sealed class AuthorizationFlowService : IAuthorizationFlowService
     {
         private readonly IAuthorizationCodeRepository _authCodeRepo;
         private readonly IRefreshTokenRepository _refreshTokenRepo;
@@ -766,7 +766,7 @@ namespace Authentication.DomainService.Authentication
                     codeModel.TargetedTenantId = claimTenantId;
                 }
 
-                Console.WriteLine(codeModel);
+                _logger.LogDebug("Authorization code model: {CodeModel}", codeModel);
 
                 await _authCodeRepo.CreateAsync(codeModel);
 
@@ -991,8 +991,7 @@ namespace Authentication.DomainService.Authentication
             // Fallback: client not configured for cookie-based token delivery or domain resolution failed
             if (useTokensCookie && !exchangeResult.CanSetCookies)
             {
-               // _logger.LogWarning($"Cannot set cookies for client {client_id}: domain resolution failed. Returning tokens in response body.");
-                Console.WriteLine($"Cannot set cookies for client {client_id}: domain resolution failed. Returning tokens in response body.");
+                _logger.LogWarning("Cannot set cookies for client {ClientId}: domain resolution failed. Returning tokens in response body.", client_id);
             }
 
             return new OkObjectResult(new

--- a/server/Authentication.DomainService/Authentication/IAuthenticationFlowService.cs
+++ b/server/Authentication.DomainService/Authentication/IAuthenticationFlowService.cs
@@ -17,7 +17,7 @@ namespace Authentication.DomainService.Authentication
         Task<IActionResult> ExecuteStopImpersonationAsync(StopImpersonationRequest request, HttpRequest httpRequest, HttpResponse httpResponse);
     }
 
-    public class AuthenticationFlowResult
+    public sealed class AuthenticationFlowResult
     {
         public TokenResponse? TokenResponse { get; set; }
         public int StatusCode { get; set; } = StatusCodes.Status400BadRequest;
@@ -27,7 +27,7 @@ namespace Authentication.DomainService.Authentication
         public string? CaptchaSiteKey { get; set; }
     }
 
-    public class GetContextForProjectResult
+    public sealed class GetContextForProjectResult
     {
         public bool IsSuccess { get; set; }
         public string? ContextId { get; set; }

--- a/server/Authentication.DomainService/Authentication/IAuthorizationFlowService.cs
+++ b/server/Authentication.DomainService/Authentication/IAuthorizationFlowService.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class OidcLoginRequest
+    public sealed class OidcLoginRequest
     {
         [System.Text.Json.Serialization.JsonPropertyName("username")]
         public string? Username { get; set; }
@@ -50,7 +50,7 @@ namespace Authentication.DomainService.Authentication
         public string? CaptchaCode { get; set; }
     }
 
-    public class OidcLoginResponse
+    public sealed class OidcLoginResponse
     {
         [System.Text.Json.Serialization.JsonPropertyName("status")]
         public string Status { get; set; } = "success"; // "success" | "account_selection_required"
@@ -65,7 +65,7 @@ namespace Authentication.DomainService.Authentication
         public string? Code { get; set; }
     }
 
-    public class OidcAccountInfo
+    public sealed class OidcAccountInfo
     {
         [System.Text.Json.Serialization.JsonPropertyName("user_id")]
         public string UserId { get; set; } = string.Empty;

--- a/server/Authentication.DomainService/Authentication/IMfaPolicyService.cs
+++ b/server/Authentication.DomainService/Authentication/IMfaPolicyService.cs
@@ -8,7 +8,7 @@ namespace Authentication.DomainService.Authentication
         Task<MfaPolicyDecision> EvaluateAsync(User user, string? clientId, CancellationToken cancellationToken = default);
     }
 
-    public class MfaPolicyDecision
+    public sealed class MfaPolicyDecision
     {
         public bool Required { get; set; }
         public string Reason { get; set; } = string.Empty;

--- a/server/Authentication.DomainService/Authentication/IdpService.cs
+++ b/server/Authentication.DomainService/Authentication/IdpService.cs
@@ -19,7 +19,7 @@ namespace Authentication.DomainService.Authentication
     /// IDP Service
     /// Manages identity provider authentication flow, token exchange, and OIDC operations
     /// </summary>
-    public class IdpService : IIdpService
+    public sealed class IdpService : IIdpService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly IAuthorizationCodeRepository _authCodeRepo;
@@ -195,7 +195,6 @@ namespace Authentication.DomainService.Authentication
 
                 // Exchange authorization code for tokens at IdP
                 var tokenEndpoint = identityProvider.TokenUrl;
-                // var tokenEndpoint = "https://dev-iam.blocksdevelopers.com:5001/api/oidc/token?tenant_id=f080a1bea04280a72149fd689d50a48c";
  
                 var form = new Dictionary<string, string>
                 {

--- a/server/Authentication.DomainService/Authentication/LogoutRequest.cs
+++ b/server/Authentication.DomainService/Authentication/LogoutRequest.cs
@@ -1,16 +1,16 @@
 namespace Authentication.DomainService.Authentication
 {
-    public class LogoutRequest
+    public sealed class LogoutRequest
     {
         public string? RefreshToken { get; set; }
     }
 
-    public class LogoutAllRequest
+    public sealed class LogoutAllRequest
     {
         public bool UseBackchannel { get; set; } = false;
     }
 
-    public class LogoutResponse
+    public sealed class LogoutResponse
     {
         public bool IsSuccess { get; set; }
     }

--- a/server/Authentication.DomainService/Authentication/MfaAuditService.cs
+++ b/server/Authentication.DomainService/Authentication/MfaAuditService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class MfaAuditService : IMfaAuditService
+    public sealed class MfaAuditService : IMfaAuditService
     {
         private readonly IAuditLogRepository _auditLogRepository;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -38,7 +38,7 @@ namespace Authentication.DomainService.Authentication
                     UserId = auditEvent.UserId,
                     ClientId = auditEvent.ClientId,
                     TenantId = tenantId,
-                    IpAddress = auditEvent.IpAddress ?? GetClientIp(http),
+                    IpAddress = auditEvent.IpAddress ?? GetClientIpAddress(http),
                     UserAgent = auditEvent.UserAgent ?? (http?.Request?.Headers?.UserAgent.ToString() ?? string.Empty),
                     Severity = auditEvent.Severity,
                     Status = auditEvent.Status,
@@ -63,7 +63,5 @@ namespace Authentication.DomainService.Authentication
             }
             return "unknown";
         }
-
-        private static string GetClientIp(HttpContext? context) => GetClientIpAddress(context);
     }
 }

--- a/server/Authentication.DomainService/Authentication/MfaPolicyService.cs
+++ b/server/Authentication.DomainService/Authentication/MfaPolicyService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Authentication
 {
-    public class MfaPolicyService : IMfaPolicyService
+    public sealed class MfaPolicyService : IMfaPolicyService
     {
         private readonly IMfaConfigurationService _mfaConfigurationService;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/Authentication/RequestModel/GetAuthenticationConfigurationRequest.cs
+++ b/server/Authentication.DomainService/Authentication/RequestModel/GetAuthenticationConfigurationRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Authentication.RequestModel
 {
-    public class GetAuthenticationConfigurationRequest
+    public sealed class GetAuthenticationConfigurationRequest
     {
     }
 }

--- a/server/Authentication.DomainService/Authentication/RequestModel/UpdateAuthenticationConfigurationRequest.cs
+++ b/server/Authentication.DomainService/Authentication/RequestModel/UpdateAuthenticationConfigurationRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Authentication.RequestModel
 {
-    public class UpdateAuthenticationConfigurationRequest
+    public sealed class UpdateAuthenticationConfigurationRequest
     {
         public string ItemId { get; set; }
 

--- a/server/Authentication.DomainService/OAuth/CertificateProvider/AzureVaultCertificateProvider.cs
+++ b/server/Authentication.DomainService/OAuth/CertificateProvider/AzureVaultCertificateProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class AzureVaultCertificateProvider : ICertificateProvider
+    public sealed class AzureVaultCertificateProvider : ICertificateProvider
     {
         private readonly ILogger _logger;
         private SecretClient _secretClient;
@@ -60,7 +60,7 @@ namespace Authentication.DomainService.OAuth
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Error retrieving secret '{key}': {e.Message}");
+                _logger.LogError(e, "Error retrieving secret {Key}", key);
                 return string.Empty;
             }
         }

--- a/server/Authentication.DomainService/OAuth/CertificateProvider/CertificateProviderFactory.cs
+++ b/server/Authentication.DomainService/OAuth/CertificateProvider/CertificateProviderFactory.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class CertificateProviderFactory : ICertificateProviderFactory
+    public sealed class CertificateProviderFactory : ICertificateProviderFactory
     {
         private readonly ILogger<CertificateProviderFactory> _logger;
         private readonly IBlocksSecret _blocksSecret;

--- a/server/Authentication.DomainService/OAuth/CertificateProvider/FileSystemCertificateProvider.cs
+++ b/server/Authentication.DomainService/OAuth/CertificateProvider/FileSystemCertificateProvider.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class FileSystemCertificateProvider : ICertificateProvider
+    public sealed class FileSystemCertificateProvider : ICertificateProvider
     {
         private readonly ILogger _logger;
 
@@ -14,9 +14,15 @@ namespace Authentication.DomainService.OAuth
 
         public async Task<byte[]> GetCertificateAsync(string key)
         {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                _logger.LogError("Certificate key is required for file-system provider");
+                return Array.Empty<byte>();
+            }
+
             try
             {
-                var path = "";
+                var path = Path.Combine(AppContext.BaseDirectory, key);
                 return await File.ReadAllBytesAsync(path);
             }
             catch (Exception e)

--- a/server/Authentication.DomainService/OAuth/CertificateProvider/MongodbCertificateProvider.cs
+++ b/server/Authentication.DomainService/OAuth/CertificateProvider/MongodbCertificateProvider.cs
@@ -5,7 +5,7 @@ using MongoDB.Driver;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class MongodbCertificateProvider : ICertificateProvider
+    public sealed class MongodbCertificateProvider : ICertificateProvider
     {
         private readonly ILogger _logger;
         private readonly IMongoDatabase _database;
@@ -28,7 +28,7 @@ namespace Authentication.DomainService.OAuth
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error retrieving certificate from file system");
+                _logger.LogError(e, "Error retrieving certificate from MongoDB");
                 return Array.Empty<byte>();
             }
         }

--- a/server/Authentication.DomainService/OAuth/JwtAccessToken.cs
+++ b/server/Authentication.DomainService/OAuth/JwtAccessToken.cs
@@ -3,7 +3,7 @@ using System.Security.Claims;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class JwtAccessToken
+    public sealed class JwtAccessToken
     {
         public string? Issuer { get; set; }
         public string? Audience { get; set; }

--- a/server/Authentication.DomainService/OAuth/JwtAccessTokenProvider.cs
+++ b/server/Authentication.DomainService/OAuth/JwtAccessTokenProvider.cs
@@ -13,7 +13,7 @@ using Authentication.DomainService.OAuth.RequestModel;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class JwtAccessTokenProvider : IJwtAccessTokenProvider
+    public sealed class JwtAccessTokenProvider : IJwtAccessTokenProvider
     {
         private readonly ILogger<JwtAccessTokenProvider> _logger;
         private readonly IDatabase _cacheDb;
@@ -88,10 +88,6 @@ namespace Authentication.DomainService.OAuth
                 resolvedOrgId = tokenRequest.OrganizationId;
             }
             claimsIdentity.AddClaim(new Claim(BlocksContext.ORGANIZATION_ID_CLAIM, resolvedOrgId));
-            // claimsIdentity.AddClaim(new Claim(BlocksContext.EMAIL_CLAIM, user.Email ?? string.Empty));
-            // claimsIdentity.AddClaim(new Claim(BlocksContext.USER_NAME_CLAIM, user.UserName ?? string.Empty));
-            // claimsIdentity.AddClaim(new Claim(BlocksContext.DISPLAY_NAME_CLAIM, $"{user.FirstName ?? string.Empty} {user.LastName ?? string.Empty}".Trim()));
-            // claimsIdentity.AddClaim(new Claim(BlocksContext.PHONE_NUMBER_CLAIM, user.PhoneNumber ?? string.Empty));
             claimsIdentity.AddClaim(new Claim("token_version", user.TokenVersion.ToString(), ClaimValueTypes.Integer32));
             claimsIdentity.AddClaim(new Claim("security_stamp", user.SecurityStamp ?? string.Empty));
 

--- a/server/Authentication.DomainService/OAuth/OAuthError.cs
+++ b/server/Authentication.DomainService/OAuth/OAuthError.cs
@@ -128,7 +128,7 @@ namespace Authentication.DomainService.OAuth
             return new TokenResponse
             {
                 Error = UserInActiveOrNotVerified,
-                ErrorDescription = $"User is not exist within {organization} organization",
+                ErrorDescription = $"User does not exist within {organization} organization",
                 StatusCode = 400
             };
         }

--- a/server/Authentication.DomainService/OAuth/OAuthJwtAccessTokenManager.cs
+++ b/server/Authentication.DomainService/OAuth/OAuthJwtAccessTokenManager.cs
@@ -17,7 +17,7 @@ using Authentication.DomainService.Shared;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class OAuthJwtAccessTokenManager : IOAuthJwtAccessTokenManager
+    public sealed class OAuthJwtAccessTokenManager : IOAuthJwtAccessTokenManager
     {
         private readonly IJwtAccessTokenProvider _jwtAccessTokenProvider;
         private readonly IAuthenticationDomainService _authenticationDomainService;

--- a/server/Authentication.DomainService/OAuth/RequestModel/AuthenticationRequestModels.cs
+++ b/server/Authentication.DomainService/OAuth/RequestModel/AuthenticationRequestModels.cs
@@ -3,7 +3,7 @@ namespace Authentication.DomainService.OAuth.RequestModel
     using Iam.DomainService.Entities;
     using System.Text.Json.Serialization;
 
-    public class EmbeddedLoginRequest
+    public sealed class EmbeddedLoginRequest
     {
         [JsonPropertyName("client_id")]
         public string? ClientId { get; set; }
@@ -24,7 +24,7 @@ namespace Authentication.DomainService.OAuth.RequestModel
         public UserMfaType? MfaType { get; set; }
     }
 
-    public class SocialLoginRequest
+    public sealed class SocialLoginRequest
     {
         [JsonPropertyName("client_id")]
         public string? ClientId { get; set; }
@@ -45,7 +45,7 @@ namespace Authentication.DomainService.OAuth.RequestModel
         public UserMfaType? MfaType { get; set; }
     }
 
-    public class OidcCallbackRequest
+    public sealed class OidcCallbackRequest
     {
         [JsonPropertyName("code")]
         public string Code { get; set; } = string.Empty;
@@ -53,7 +53,7 @@ namespace Authentication.DomainService.OAuth.RequestModel
         public string State { get; set; } = string.Empty;
     }
 
-    public class OidcCodeExchangeRequest
+    public sealed class OidcCodeExchangeRequest
     {
         [JsonPropertyName("code")]
         public string Code { get; set; } = string.Empty;
@@ -71,13 +71,13 @@ namespace Authentication.DomainService.OAuth.RequestModel
         public string? TenantId { get; set; }
     }
 
-    public class SwitchOrganizationRequest
+    public sealed class SwitchOrganizationRequest
     {
         [JsonPropertyName("organization_id")]
         public string OrganizationId { get; set; } = string.Empty;
     }
 
-    public class RefreshRequest
+    public sealed class RefreshRequest
     {
         [JsonPropertyName("refresh_token")]
         public string? RefreshToken { get; set; }

--- a/server/Authentication.DomainService/OAuth/RequestModel/AuthorizeRequest.cs
+++ b/server/Authentication.DomainService/OAuth/RequestModel/AuthorizeRequest.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Authentication.DomainService.OAuth.RequestModel
 {
-    public class AuthorizeRequest
+    public sealed class AuthorizeRequest
     {
         [FromQuery(Name = "response_type")]
         public string? ResponseType { get; set; }

--- a/server/Authentication.DomainService/OAuth/RequestModel/GetSocialLogInEndPointRequest.cs
+++ b/server/Authentication.DomainService/OAuth/RequestModel/GetSocialLogInEndPointRequest.cs
@@ -10,7 +10,7 @@ namespace Authentication.DomainService.OAuth.RequestModel
         public bool SendAsResponse { get; set; } = true;
     }
 
-    public class GetSocialLogInEndPointResponse
+    public sealed class GetSocialLogInEndPointResponse
     {
         public bool IsAResponse { get; set; }
         public string? ProviderUrl { get; set; }

--- a/server/Authentication.DomainService/OAuth/RequestModel/LoginRequest.cs
+++ b/server/Authentication.DomainService/OAuth/RequestModel/LoginRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.OAuth.RequestModel
 {
-    public class LoginRequest
+    public sealed class LoginRequest
     {
         public string? Username { get; set; }
         public string? Password { get; set; }

--- a/server/Authentication.DomainService/OAuth/RequestModel/TokenRequest.cs
+++ b/server/Authentication.DomainService/OAuth/RequestModel/TokenRequest.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Authentication.DomainService.OAuth.RequestModel
 {
-    public class TokenRequest
+    public sealed class TokenRequest
     {
         public string? GrantType { get; set; }
         public string? Code { get; set; }

--- a/server/Authentication.DomainService/OAuth/ResponseModel/TokenResponse.cs
+++ b/server/Authentication.DomainService/OAuth/ResponseModel/TokenResponse.cs
@@ -2,7 +2,7 @@ using Iam.DomainService.Entities;
 
 namespace Authentication.DomainService.OAuth.ResponseModel
 {
-    public class TokenResponse
+    public sealed class TokenResponse
     {
         public string? AccessToken { get; set; }
         public string TokenType { get; set; } = "Bearer";

--- a/server/Authentication.DomainService/OAuth/Services/BYOSsoAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/BYOSsoAuthorizationService.cs
@@ -26,7 +26,6 @@ namespace Authentication.DomainService.OAuth.Services
 
             if (user == null)
             {
-                // return await CreateUser(stateInfo, externalUser); // for now, we will not auto create user, return error instead. Will add auto create user in the future if needed.   
                 return (null, string.Empty);
             }
 

--- a/server/Authentication.DomainService/OAuth/Services/BiometricAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/BiometricAuthorizationService.cs
@@ -6,7 +6,7 @@ using Iam.DomainService.Entities;
 
 namespace Authentication.DomainService.OAuth.Services
 {
-    public class BiometricAuthorizationService : ITokenService
+    public sealed class BiometricAuthorizationService : ITokenService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly IOAuthJwtAccessTokenManager _oAuthJwtAccessTokenManager;

--- a/server/Authentication.DomainService/OAuth/Services/ClientCredentialAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/ClientCredentialAuthorizationService.cs
@@ -6,12 +6,13 @@ using Authentication.DomainService.Services;
 using Iam.DomainService.Entities;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Authentication.DomainService.Utilities;
 
 namespace Authentication.DomainService.OAuth.Services
 {
-    public class ClientCredentialAuthorizationService : ITokenService
+    public sealed class ClientCredentialAuthorizationService : ITokenService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly ICertificateProviderFactory _certificateProviderFactory;
@@ -49,25 +50,6 @@ namespace Authentication.DomainService.OAuth.Services
                     ErrorDescription = "organization_id (or org_id) is required for client_credentials"
                 };
             }
-
-            //var orgPermissions = ResolveOrgPermissions(client!, requestedOrgId);
-            //if (orgPermissions.Count == 0)
-            //{
-            //    return new TokenResponse
-            //    {
-            //        Error = "invalid_scope",
-            //        ErrorDescription = "No permissions configured for the requested organization"
-            //    };
-            //}
-
-            //if (orgPermissions.Count > 10)
-            //{
-            //    return new TokenResponse
-            //    {
-            //        Error = "invalid_scope",
-            //        ErrorDescription = "A maximum of 10 permissions is allowed per organization"
-            //    };
-            //}
 
             var jwtToken = await GetJwtAccessToken(authenticationConfiguration, client!, requestedOrgId, []);
             var accessToken =  OAuthJwtAccessTokenManager.CreateJwtAccessToken(jwtToken);
@@ -210,7 +192,7 @@ namespace Authentication.DomainService.OAuth.Services
                     ErrorDescription = "No client found"
                 },
 
-                _ when request.ClientSecret != client.ClientSecret => new TokenResponse
+                _ when !SecretsMatch(request.ClientSecret, client.ClientSecret) => new TokenResponse
                 {
                     Error = "invalid_client",
                     ErrorDescription = "Client secret not match"
@@ -222,8 +204,20 @@ namespace Authentication.DomainService.OAuth.Services
                     ErrorDescription = "Client is not active"
                 },
 
-                _ => null 
+                _ => null
             };
+        }
+
+        private static bool SecretsMatch(string? requestSecret, string? clientSecret)
+        {
+            if (string.IsNullOrEmpty(requestSecret) || string.IsNullOrEmpty(clientSecret))
+            {
+                return false;
+            }
+
+            var requestBytes = Encoding.UTF8.GetBytes(requestSecret);
+            var clientBytes = Encoding.UTF8.GetBytes(clientSecret);
+            return CryptographicOperations.FixedTimeEquals(requestBytes, clientBytes);
         }
 
     }

--- a/server/Authentication.DomainService/OAuth/Services/ClientUserCodeAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/ClientUserCodeAuthorizationService.cs
@@ -6,7 +6,7 @@ using Iam.DomainService.Entities;
 
 namespace Authentication.DomainService.OAuth.Services
 {
-    public class ClientUserCodeAuthorizationService : ITokenService
+    public sealed class ClientUserCodeAuthorizationService : ITokenService
     {
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly IOAuthJwtAccessTokenManager _oAuthJwtAccessTokenManager;

--- a/server/Authentication.DomainService/OAuth/Services/MfaAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/MfaAuthorizationService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth.Services
 {
-    public class MfaAuthorizationService : ITokenService
+    public sealed class MfaAuthorizationService : ITokenService
     {
         private readonly ILogger<MfaAuthorizationService> _logger;
         private readonly IOAuthJwtAccessTokenManager _oAuthJwtAccessTokenManager;
@@ -119,7 +119,7 @@ namespace Authentication.DomainService.OAuth.Services
                 ClientId = request.ClientId,
                 MfaType = request.MfaType,
                 Status = "failure",
-                Severity = justLocked ? "WARN" : "WARN"
+                Severity = "WARN"
             });
 
             if (justLocked)

--- a/server/Authentication.DomainService/OAuth/Services/PasswordAuthenticationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/PasswordAuthenticationService.cs
@@ -12,7 +12,7 @@ using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class PasswordAuthenticationService : ITokenService
+    public sealed class PasswordAuthenticationService : ITokenService
     {
         private readonly ILogger<PasswordAuthenticationService> _logger;
         private readonly IOAuthJwtAccessTokenManager _oAuthJwtAccessTokenManager;

--- a/server/Authentication.DomainService/OAuth/Services/RefreshTokenAuthenticationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/RefreshTokenAuthenticationService.cs
@@ -10,7 +10,7 @@ using Authentication.DomainService.Utilities;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class RefreshTokenAuthenticationService : ITokenService
+    public sealed class RefreshTokenAuthenticationService : ITokenService
     {
         private readonly ILogger<RefreshTokenAuthenticationService> _logger;
         private readonly IJwtAccessTokenProvider _jwtAccessTokenProvider;

--- a/server/Authentication.DomainService/OAuth/Services/SSOConsentAuthenticationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/SSOConsentAuthenticationService.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.OAuth.Services
 {
-    public class SSOConsentAuthenticationService : ITokenService
+    public sealed class SSOConsentAuthenticationService : ITokenService
     {
         private readonly ICacheClient _cacheClient;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/OAuth/Services/SocialAuthorizationService.cs
+++ b/server/Authentication.DomainService/OAuth/Services/SocialAuthorizationService.cs
@@ -45,7 +45,7 @@ namespace Authentication.DomainService.OAuth
 
         protected override TokenResponse CreateUserNotFoundError(string userName)
         {
-            return new TokenResponse { Error = "user_not_found", ErrorDescription = $"{userName} is not exit", StatusCode = 401 };
+            return new TokenResponse { Error = "user_not_found", ErrorDescription = $"{userName} does not exist", StatusCode = 401 };
         }
 
         public override async Task<(User? user, string redirectUrl)> GetUser(StateInfo stateInfo, IExternalUserData externalUser)

--- a/server/Authentication.DomainService/OAuth/Services/SocialAuthorizationServiceBase.cs
+++ b/server/Authentication.DomainService/OAuth/Services/SocialAuthorizationServiceBase.cs
@@ -144,7 +144,7 @@ namespace Authentication.DomainService.OAuth.Services
 
         protected virtual TokenResponse CreateUserNotFoundError(string userName)
         {
-            return new TokenResponse { Error = "user_not_found", ErrorDescription = $"{userName} is not exit", StatusCode = 401 };
+            return new TokenResponse { Error = "user_not_found", ErrorDescription = $"{userName} does not exist", StatusCode = 401 };
         }
 
         public abstract Task<(User? user, string redirectUrl)> GetUser(StateInfo stateInfo, IExternalUserData externalUser);

--- a/server/Authentication.DomainService/OAuth/SocialServices/AppleLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/AppleLogInService.cs
@@ -10,7 +10,7 @@ using System.Security.Cryptography;
 
 namespace Authentication.DomainService.OAuth.SocialServices
 {
-    public class AppleLogInService : ISocialLogInService
+    public sealed class AppleLogInService : ISocialLogInService
     {
         private readonly ILogger<AppleLogInService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/OAuth/SocialServices/BYOSsoLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/BYOSsoLogInService.cs
@@ -35,7 +35,6 @@ namespace Authentication.DomainService.OAuth
                 };
 
             var (response, error) = await _httpService.SendFormUrlEncoded<SocialOauthAccessToken>(HttpMethod.Post, postData, identityProvider.TokenUrl);
-            _logger.LogInformation("access token: {Response}", response);
             if (!string.IsNullOrWhiteSpace(error) || response == null)
             {
                 _logger.LogError("Error while getting access token: {Error}", error);
@@ -143,7 +142,7 @@ namespace Authentication.DomainService.OAuth
                     user.ProfileImageUrl = result.TryGetProperty("profilePicture", out JsonElement picture3) ? picture3.ToString() : "";
                     break;
 
-                case SocialLogInTypes.KeyCloak:
+                case SocialLogInTypes.Keycloak:
                     user.ExternalProviderUserId = result.TryGetProperty("sub", out JsonElement sub4) ? sub4.ToString() : "";
                     user.Email = result.TryGetProperty("email", out JsonElement email7) ? email7.ToString() : "";
                     user.DisplayName = result.TryGetProperty("name", out JsonElement name5) ? name5.ToString() : result.TryGetProperty("preferred_username", out JsonElement preferred1) ? preferred1.ToString() : "";

--- a/server/Authentication.DomainService/OAuth/SocialServices/FaceBookLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/FaceBookLogInService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth.SocialServices
 {
-    public class FaceBookLogInService : ISocialLogInService
+    public sealed class FaceBookLogInService : ISocialLogInService
     {
         private readonly ILogger<FaceBookLogInService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;
@@ -31,9 +31,9 @@ namespace Authentication.DomainService.OAuth.SocialServices
                 return new SocialCallbackResult { ExternalUserData = new FaceBookUserData() };
             }
 
-            string faceBookGetAccessTokenUri = string.Format("{0}?client_id={1}&redirect_uri={2}&client_secret={3}&code={4}", identityProvider.TokenUrl, identityProvider.ClientId, stateInfo.RedirectUri, identityProvider.ClientSecret, stateInfo.Code);
-            _logger.LogInformation("faceBook Access Token Uri {AccessTokenUri}", faceBookGetAccessTokenUri);
-            var (tokenResponse, error) = await _httpService.Get<SocialOauthAccessToken>(faceBookGetAccessTokenUri);
+            var faceBookGetAccessTokenUri = new Uri(string.Format("{0}?client_id={1}&redirect_uri={2}&client_secret={3}&code={4}", identityProvider.TokenUrl, identityProvider.ClientId, stateInfo.RedirectUri, identityProvider.ClientSecret, stateInfo.Code));
+            _logger.LogInformation("facebook access token host: {Host}", faceBookGetAccessTokenUri.Host);
+            var (tokenResponse, error) = await _httpService.Get<SocialOauthAccessToken>(faceBookGetAccessTokenUri.ToString());
 
             if (!string.IsNullOrWhiteSpace(error) || tokenResponse == null)
             {

--- a/server/Authentication.DomainService/OAuth/SocialServices/GithubLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/GithubLogInService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class GithubLogInService : ISocialLogInService
+    public sealed class GithubLogInService : ISocialLogInService
     {
         private readonly ILogger<GithubLogInService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/OAuth/SocialServices/IExternalUserData.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/IExternalUserData.cs
@@ -21,7 +21,7 @@ namespace Authentication.DomainService.OAuth
         public new string EmployeeId { get; set; }
     }
 
-    public class GoogleUserData : IExternalUserData
+    public sealed class GoogleUserData : IExternalUserData
     {
         [JsonPropertyName("name")]
         public new string DisplayName { get; set; }
@@ -52,7 +52,7 @@ namespace Authentication.DomainService.OAuth
         public new string EmployeeId { get; set; }
     }
 
-    public class MicrosoftUserData : IExternalUserData
+    public sealed class MicrosoftUserData : IExternalUserData
     {
         [JsonPropertyName("displayName")]
         public new string DisplayName { get; set; }
@@ -89,7 +89,7 @@ namespace Authentication.DomainService.OAuth
         public List<string> Permissions { get; set; } = [];
     }
 
-    public class BYOSsoUserData : IExternalUserData
+    public sealed class BYOSsoUserData : IExternalUserData
     {
         public string DisplayName { get; set; } = string.Empty;
         public string FirstName { get; set; } = string.Empty;
@@ -108,7 +108,7 @@ namespace Authentication.DomainService.OAuth
         public new string EmployeeId { get; set; }
     }
 
-    public class GithubUserData : IExternalUserData
+    public sealed class GithubUserData : IExternalUserData
     {
         [JsonPropertyName("id")]
         public long Id { get; set; }
@@ -139,7 +139,7 @@ namespace Authentication.DomainService.OAuth
         public new string EmployeeId { get; set; }
     }
 
-    public class GithubEmail
+    public sealed class GithubEmail
     {
         [JsonPropertyName("email")]
         public string Email { get; set; }
@@ -154,7 +154,7 @@ namespace Authentication.DomainService.OAuth
         public string Visibility { get; set; }
     }
 
-    public class LinkedinUserData : IExternalUserData
+    public sealed class LinkedinUserData : IExternalUserData
     {
         [JsonPropertyName("sub")]
         public string ExternalProviderUserId { get; set; }
@@ -184,7 +184,7 @@ namespace Authentication.DomainService.OAuth
         public new string EmployeeId { get; set; }
     }
 
-    public class LinkedinUserInfo
+    public sealed class LinkedinUserInfo
     {
         [JsonPropertyName("sub")]
         public string Sub { get; set; }
@@ -247,7 +247,7 @@ namespace Authentication.DomainService.OAuth
     public class AppleUserData : StandardSocialUserDataBase
     {
     }
-    public class AppleIdToken
+    public sealed class AppleIdToken
     {
 
         [JsonProperty("email")]

--- a/server/Authentication.DomainService/OAuth/SocialServices/LinkedinLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/LinkedinLogInService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.OAuth.SocialServices
 {
-    public class LinkedinLogInService : ISocialLogInService
+    public sealed class LinkedinLogInService : ISocialLogInService
     {
         private readonly ILogger<LinkedinLogInService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;
@@ -52,7 +52,7 @@ namespace Authentication.DomainService.OAuth.SocialServices
                 return new SocialCallbackResult { ExternalUserData = new LinkedinUserData() };
             }
 
-            var profileUrl = identityProvider.UserInfoUrl + $"oauth2_access_token={tokenResponse.AccessToken}";
+            var profileUrl = identityProvider.UserInfoUrl + $"?oauth2_access_token={tokenResponse.AccessToken}";
 
             (var userInfo, var profileError) = await _httpService.Get<LinkedinUserInfo>(
                 profileUrl);

--- a/server/Authentication.DomainService/OAuth/SocialServices/SocialCallbackResult.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/SocialCallbackResult.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.OAuth
 {
-    public class SocialCallbackResult
+    public sealed class SocialCallbackResult
     {
         public IExternalUserData ExternalUserData { get; set; } = new BYOSsoUserData();
         public string? AccessToken { get; set; }

--- a/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInServiceBase.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInServiceBase.cs
@@ -12,8 +12,8 @@ namespace Authentication.DomainService.OAuth
         protected readonly IAuthenticationRepository _authenticationRepository;
         protected readonly ICacheClient _cacheClient;
         protected readonly IHttpService _httpService;
-        private const string googleProvider = "google";
-        private const string microsoftProvider = "microsoft";
+        private const string GoogleProvider = "google";
+        private const string MicrosoftProvider = "microsoft";
 
         protected SocialLogInServiceBase(
             ILogger logger,
@@ -56,14 +56,14 @@ namespace Authentication.DomainService.OAuth
 
             var externalUser = stateInfo.Provider switch
             {
-                googleProvider => await GetGoogleProfileVerification(identityProvider.UserInfoUrl, response.AccessToken),
-                microsoftProvider => await GetMicrosoftProfileVerification(identityProvider.UserInfoUrl, response.AccessToken, response.IdToken),
+                GoogleProvider => await GetGoogleProfileVerification(identityProvider.UserInfoUrl, response.AccessToken),
+                MicrosoftProvider => await GetMicrosoftProfileVerification(identityProvider.UserInfoUrl, response.AccessToken, response.IdToken),
                 _ => CreateEmptyUserData()
             };
 
             externalUser.Permissions = identityProvider.InitialPermissions;
 
-            Console.WriteLine($"IntraId Roles: {string.Join(", ", externalUser.Roles)}");
+            _logger.LogDebug("IntraId Roles: {Roles}", string.Join(", ", externalUser.Roles));
 
             if (externalUser.Roles.Count > 0)
                 externalUser.Roles.AddRange(identityProvider.InitialRoles);

--- a/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInServiceProvider.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInServiceProvider.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class SocialLogInServiceProvider : ISocialLogInServiceProvider
+    public sealed class SocialLogInServiceProvider : ISocialLogInServiceProvider
     {
         private readonly IDictionary<string, ISocialLogInService> _socialLogIns;
         private readonly ISocialLogInService _defaultService;

--- a/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInTypes.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/SocialLogInTypes.cs
@@ -6,13 +6,12 @@ namespace Authentication.DomainService.OAuth
         public const string FaceBook = "facebook";
         public const string LinkedIn = "linkedin";
         public const string Microsoft = "microsoft";
-        public const string KeyClock = "keyclock";
         public const string Apple = "apple";
         public const string Github = "github";
         public const string BYOSso = "byosso";
         public const string AzureAd = "azuread";
         public const string Okta = "okta";
-        public const string KeyCloak = "keycloak";
+        public const string Keycloak = "keycloak";
         public const string Ping = "ping";
         public const string Adfs = "adfs";
         public const string WindowsLive = "windowslive";

--- a/server/Authentication.DomainService/OAuth/SocialServices/SocialOauthAccessToken.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/SocialOauthAccessToken.cs
@@ -2,10 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class SocialOauthAccessToken
+    public sealed class SocialOauthAccessToken
     {
         [JsonPropertyName("expires_in")]
-        public int ExpireIn { get; set; }
+        public int ExpiresIn { get; set; }
 
         [JsonPropertyName("token_type")]
         public string TokenType { get; set; }
@@ -26,7 +26,7 @@ namespace Authentication.DomainService.OAuth
         public string ExternalProviderUserId { get; set; }
     }
 
-    public class TwitterOauthAccessToken
+    public sealed class TwitterOauthAccessToken
     {
         [JsonPropertyName("token_type")]
         public string TokenType { get; set; }

--- a/server/Authentication.DomainService/OAuth/SocialServices/TwitterLogInService.cs
+++ b/server/Authentication.DomainService/OAuth/SocialServices/TwitterLogInService.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.OAuth.SocialServices
 {
-    public class TwitterLogInService : ISocialLogInService
+    public sealed class TwitterLogInService : ISocialLogInService
     {
         private readonly ILogger<TwitterLogInService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/OAuth/TokenPayload.cs
+++ b/server/Authentication.DomainService/OAuth/TokenPayload.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class TokenPayload
+    public sealed class TokenPayload
     {
         [FromForm(Name = "grant_type")]
         public string GrantType { get; set; }
@@ -45,7 +45,7 @@ namespace Authentication.DomainService.OAuth
         public string BiometricId { get; set; } = string.Empty;
 
         [FromForm(Name = "biometric_key")]
-        public string BiometriKey { get; set; } = string.Empty;
+        public string BiometricKey { get; set; } = string.Empty;
 
         [FromForm(Name = "client_id")]
         public string ClientId { get; set; } = string.Empty;

--- a/server/Authentication.DomainService/OAuth/Validators/SaveSsoCredentialRequestValidator.cs
+++ b/server/Authentication.DomainService/OAuth/Validators/SaveSsoCredentialRequestValidator.cs
@@ -5,10 +5,14 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.OAuth
 {
-    public class SaveSsoCredentialRequestValidator : AbstractValidator<SaveSsoCredentialRequest>
+    public sealed class SaveSsoCredentialRequestValidator : AbstractValidator<SaveSsoCredentialRequest>
     {
-        public SaveSsoCredentialRequestValidator()
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public SaveSsoCredentialRequestValidator(IHttpClientFactory httpClientFactory)
         {
+            _httpClientFactory = httpClientFactory;
+
             RuleFor(x => x.WellKnownUrl)
                 .Cascade(CascadeMode.Stop)
                 .Must(BeAValidUrl)
@@ -24,11 +28,11 @@ namespace Authentication.DomainService.OAuth
                    (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
         }
 
-        private static async Task<bool> HaveValidOidcMetadataAsync(string wellKnownUrl, CancellationToken cancellationToken)
+        private async Task<bool> HaveValidOidcMetadataAsync(string wellKnownUrl, CancellationToken cancellationToken)
         {
             try
             {
-                using var httpClient = new HttpClient();
+                using var httpClient = _httpClientFactory.CreateClient(nameof(SaveSsoCredentialRequestValidator));
 
                 var response = await httpClient.GetAsync(wellKnownUrl, cancellationToken);
                 if (!response.IsSuccessStatusCode) return false;

--- a/server/Authentication.DomainService/Oidc/Contracts/OidcContracts.cs
+++ b/server/Authentication.DomainService/Oidc/Contracts/OidcContracts.cs
@@ -3,7 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Idp.DomainService.Oidc.Contracts;
 
-public class OidcClaims
+public sealed class OidcClaims
 {
     public string Sub { get; set; } = string.Empty;
     public string TenantId { get; set; } = string.Empty;
@@ -23,7 +23,7 @@ public class OidcClaims
     public List<string> Permissions { get; set; } = [];
 }
 
-public class AuthorizationCodeModel
+public sealed class AuthorizationCodeModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
     public string Code { get; set; } = string.Empty;
@@ -51,7 +51,7 @@ public class AuthorizationCodeModel
     public string? ImpersonatedUserId { get; set; } = string.Empty;
 }
 
-public class RefreshTokenModel
+public sealed class RefreshTokenModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
     public string TokenId { get; set; } = Guid.NewGuid().ToString("n");
@@ -79,7 +79,7 @@ public class RefreshTokenModel
     }
 }
 
-public class IdpSessionAccount
+public sealed class IdpSessionAccount
 {
     public string UserId { get; set; } = string.Empty;
     public string TenantId { get; set; } = string.Empty;
@@ -87,7 +87,7 @@ public class IdpSessionAccount
     public DateTime LoginAt { get; set; }
 }
 
-public class IdpSessionModel
+public sealed class IdpSessionModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
     public string SessionId { get; set; } = Guid.NewGuid().ToString("n");
@@ -107,7 +107,7 @@ public class IdpSessionModel
     }
 }
 
-public class AuditLogModel
+public sealed class AuditLogModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
     public string EventType { get; set; } = string.Empty;
@@ -123,7 +123,7 @@ public class AuditLogModel
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 }
 
-public class ConsentGrantModel
+public sealed class ConsentGrantModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
     public string UserId { get; set; } = string.Empty;
@@ -134,7 +134,7 @@ public class ConsentGrantModel
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }
 
-public class DiscoveryMetadata
+public sealed class DiscoveryMetadata
 {
     [JsonPropertyName("issuer")]
     public string Issuer { get; set; } = string.Empty;
@@ -179,7 +179,7 @@ public class DiscoveryMetadata
     public IEnumerable<string> ScopesSupported { get; set; } = ["openid", "profile", "email", "offline_access"];
 }
 
-public class OAuthAuthorizationServerMetadata
+public sealed class OAuthAuthorizationServerMetadata
 {
     [JsonPropertyName("issuer")]
     public string Issuer { get; set; } = string.Empty;
@@ -212,13 +212,13 @@ public class OAuthAuthorizationServerMetadata
     public IEnumerable<string> CodeChallengeMethodsSupported { get; set; } = ["S256"];
 }
 
-public class JwksResponse
+public sealed class JwksResponse
 {
     [JsonPropertyName("keys")]
     public List<JwkKey> Keys { get; set; } = [];
 }
 
-public class JwkKey
+public sealed class JwkKey
 {
     [JsonPropertyName("kty")]
     public string Kty { get; set; } = "RSA";

--- a/server/Authentication.DomainService/Oidc/Repositories/AuditLogRepository.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/AuditLogRepository.cs
@@ -1,21 +1,16 @@
 using Blocks.Genesis;
 using Idp.DomainService.Oidc.Contracts;
-using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace Authentication.DomainService.Oidc.Repositories
 {
-    public class AuditLogRepository : IAuditLogRepository
+    public sealed class AuditLogRepository : IAuditLogRepository
     {
         private readonly IDbContextProvider _dbContextProvider;
-        private readonly ILogger<AuditLogRepository> _logger;
 
-        public AuditLogRepository(
-            IDbContextProvider dbContextProvider,
-            ILogger<AuditLogRepository> logger)
+        public AuditLogRepository(IDbContextProvider dbContextProvider)
         {
             _dbContextProvider = dbContextProvider;
-            _logger = logger;
         }
 
         public IMongoCollection<T> GetCollection<T>()
@@ -40,103 +35,62 @@ namespace Authentication.DomainService.Oidc.Repositories
 
         public async Task<string> CreateAsync(AuditLogModel log)
         {
-            try
-            {
-                var collection = GetCollectionByName<AuditLogModel>("IdpAuditLogs");
-                await collection.InsertOneAsync(log);
-                return log.Id;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error creating audit log: {log.EventType}");
-                throw;
-            }
+            var collection = GetCollectionByName<AuditLogModel>("IdpAuditLogs");
+            await collection.InsertOneAsync(log);
+            return log.Id;
         }
 
         public async Task<IEnumerable<AuditLogModel>> GetByUserAsync(string userId, string tenantId, DateTime from, DateTime to)
         {
-            try
-            {
-                var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
-                var filter = Builders<AuditLogModel>.Filter.And(
-                    Builders<AuditLogModel>.Filter.Eq(l => l.UserId, userId),
-                    Builders<AuditLogModel>.Filter.Eq(l => l.TenantId, tenantId),
-                    Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
-                    Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
-                );
-                return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching audit logs for user: {userId}");
-                throw;
-            }
+            var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
+            var filter = Builders<AuditLogModel>.Filter.And(
+                Builders<AuditLogModel>.Filter.Eq(l => l.UserId, userId),
+                Builders<AuditLogModel>.Filter.Eq(l => l.TenantId, tenantId),
+                Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
+                Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
+            );
+            return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
         }
 
         public async Task<IEnumerable<AuditLogModel>> GetByEventTypeAsync(string eventType, DateTime from, DateTime to)
         {
-            try
-            {
-                var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
-                var filter = Builders<AuditLogModel>.Filter.And(
-                    Builders<AuditLogModel>.Filter.Eq(l => l.EventType, eventType),
-                    Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
-                    Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
-                );
-                return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching audit logs by event type: {eventType}");
-                throw;
-            }
+            var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
+            var filter = Builders<AuditLogModel>.Filter.And(
+                Builders<AuditLogModel>.Filter.Eq(l => l.EventType, eventType),
+                Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
+                Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
+            );
+            return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
         }
 
         public async Task<IEnumerable<AuditLogModel>> GetBySeverityAsync(string severity, DateTime from, DateTime to)
         {
-            try
-            {
-                var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
-                var filter = Builders<AuditLogModel>.Filter.And(
-                    Builders<AuditLogModel>.Filter.Eq(l => l.Severity, severity),
-                    Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
-                    Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
-                );
-                return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching audit logs by severity: {severity}");
-                throw;
-            }
+            var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
+            var filter = Builders<AuditLogModel>.Filter.And(
+                Builders<AuditLogModel>.Filter.Eq(l => l.Severity, severity),
+                Builders<AuditLogModel>.Filter.Gte(l => l.Timestamp, from),
+                Builders<AuditLogModel>.Filter.Lte(l => l.Timestamp, to)
+            );
+            return await collection.Find(filter).SortByDescending(l => l.Timestamp).ToListAsync();
         }
 
         public async Task<long> GetCountAsync(string eventType = null, DateTime? from = null, DateTime? to = null)
         {
-            try
-            {
-                var collection = GetCollection<AuditLogModel>("IdpAuditLogs");
-                var filterBuilder = Builders<AuditLogModel>.Filter;
-                var filters = new List<FilterDefinition<AuditLogModel>>();
+            var collection = GetCollectionByName<AuditLogModel>("IdpAuditLogs");
+            var filterBuilder = Builders<AuditLogModel>.Filter;
+            var filters = new List<FilterDefinition<AuditLogModel>>();
 
-                if (!string.IsNullOrEmpty(eventType))
-                    filters.Add(filterBuilder.Eq(l => l.EventType, eventType));
+            if (!string.IsNullOrEmpty(eventType))
+                filters.Add(filterBuilder.Eq(l => l.EventType, eventType));
 
-                if (from.HasValue)
-                    filters.Add(filterBuilder.Gte(l => l.Timestamp, from.Value));
+            if (from.HasValue)
+                filters.Add(filterBuilder.Gte(l => l.Timestamp, from.Value));
 
-                if (to.HasValue)
-                    filters.Add(filterBuilder.Lte(l => l.Timestamp, to.Value));
+            if (to.HasValue)
+                filters.Add(filterBuilder.Lte(l => l.Timestamp, to.Value));
 
-                var filter = filters.Count > 0 ? filterBuilder.And(filters) : filterBuilder.Empty;
-                return await collection.CountDocumentsAsync(filter);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error counting audit logs");
-                throw;
-            }
+            var filter = filters.Count > 0 ? filterBuilder.And(filters) : filterBuilder.Empty;
+            return await collection.CountDocumentsAsync(filter);
         }
     }
 }
-

--- a/server/Authentication.DomainService/Oidc/Repositories/AuthorizationCodeRepository.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/AuthorizationCodeRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Oidc.Repositories
 {
-    public class AuthorizationCodeRepository : IAuthorizationCodeRepository
+    public sealed class AuthorizationCodeRepository : IAuthorizationCodeRepository
     {
         private readonly IDbContextProvider _dbContextProvider;
         private readonly ILogger<AuthorizationCodeRepository> _logger;
@@ -24,69 +24,36 @@ namespace Authentication.DomainService.Oidc.Repositories
 
         public async Task<string> CreateAsync(AuthorizationCodeModel code)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
-                await collection.InsertOneAsync(code);
-                _logger.LogInformation($"Authorization code created for user {code.UserId}, client {code.ClientId}");
-                return code.Code;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error creating authorization code");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
+            await collection.InsertOneAsync(code);
+            _logger.LogInformation("Authorization code created for user {UserId}, client {ClientId}", code.UserId, code.ClientId);
+            return code.Code;
         }
 
         public async Task<AuthorizationCodeModel> GetByCodeAsync(string code)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
-                var filter = Builders<AuthorizationCodeModel>.Filter.Eq(c => c.Code, code);
-                return await collection.Find(filter).FirstOrDefaultAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching authorization code: {code}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
+            var filter = Builders<AuthorizationCodeModel>.Filter.Eq(c => c.Code, code);
+            return await collection.Find(filter).FirstOrDefaultAsync();
         }
 
         public async Task<bool> DeleteAsync(string code)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
-                var filter = Builders<AuthorizationCodeModel>.Filter.Eq(c => c.Code, code);
-                var update = Builders<AuthorizationCodeModel>.Update
-                    .Set(c => c.IsRevoked, true)
-                    .Set(c => c.RevokedAt, DateTime.UtcNow);
+            var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
+            var filter = Builders<AuthorizationCodeModel>.Filter.Eq(c => c.Code, code);
+            var update = Builders<AuthorizationCodeModel>.Update
+                .Set(c => c.IsRevoked, true)
+                .Set(c => c.RevokedAt, DateTime.UtcNow);
 
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error soft deleting authorization code: {code}");
-                throw;
-            }
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<IEnumerable<AuthorizationCodeModel>> GetExpiredAsync()
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
-                var filter = Builders<AuthorizationCodeModel>.Filter.Lt(c => c.ExpiresAt, DateTime.UtcNow);
-                return await collection.Find(filter).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error fetching expired authorization codes");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<AuthorizationCodeModel>("IdpAuthorizationCodes");
+            var filter = Builders<AuthorizationCodeModel>.Filter.Lt(c => c.ExpiresAt, DateTime.UtcNow);
+            return await collection.Find(filter).ToListAsync();
         }
     }
 }
-

--- a/server/Authentication.DomainService/Oidc/Repositories/ITokenRevocationService.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/ITokenRevocationService.cs
@@ -37,7 +37,7 @@ namespace Authentication.DomainService.Oidc.Repositories
         Task<IEnumerable<TokenRevocationModel>> GetRevocationHistoryAsync(string userId);
     }
 
-    public class TokenRevocationResult
+    public sealed class TokenRevocationResult
     {
         public bool Success { get; set; }
         public string? Error { get; set; }
@@ -47,7 +47,7 @@ namespace Authentication.DomainService.Oidc.Repositories
     /// <summary>
     /// RFC 7662 Token Introspection Response
     /// </summary>
-    public class TokenIntrospectionResult
+    public sealed class TokenIntrospectionResult
     {
         /// <summary>
         /// REQUIRED. Boolean indicator of whether or not the presented token is currently active.

--- a/server/Authentication.DomainService/Oidc/Repositories/IdpSessionRepository.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/IdpSessionRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Oidc.Repositories
 {
-    public class IdpSessionRepository : IIdpSessionRepository
+    public sealed class IdpSessionRepository : IIdpSessionRepository
     {
         private readonly IDbContextProvider _dbContextProvider;
         private readonly ILogger<IdpSessionRepository> _logger;
@@ -24,148 +24,84 @@ namespace Authentication.DomainService.Oidc.Repositories
 
         public async Task<string> CreateAsync(IdpSessionModel session)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                await collection.InsertOneAsync(session);
-                _logger.LogInformation($"IdP session created: {session.SessionId}");
-                return session.SessionId;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error creating IdP session");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            await collection.InsertOneAsync(session);
+            _logger.LogInformation("IdP session created: {SessionId}", session.SessionId);
+            return session.SessionId;
         }
 
         public async Task<IdpSessionModel> GetBySessionIdAsync(string sessionId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                return await collection.Find(filter).FirstOrDefaultAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching IdP session: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            return await collection.Find(filter).FirstOrDefaultAsync();
         }
 
         public async Task<bool> AddAccountAsync(string sessionId, IdpSessionAccount account)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
-                var update = Builders<IdpSessionModel>.Update
-                    .Push(s => s.Accounts, account)
-                    .Set(s => s.LastActivityAt, DateTime.UtcNow)
-                    .Set(s => s.IdleExpiry, idleExpiry);
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error adding account to IdP session: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
+            var update = Builders<IdpSessionModel>.Update
+                .Push(s => s.Accounts, account)
+                .Set(s => s.LastActivityAt, DateTime.UtcNow)
+                .Set(s => s.IdleExpiry, idleExpiry);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> RemoveAccountAsync(string sessionId, string userId, string tenantId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
-                var update = Builders<IdpSessionModel>.Update
-                    .PullFilter(s => s.Accounts, a => a.UserId == userId && a.TenantId == tenantId)
-                    .Set(s => s.LastActivityAt, DateTime.UtcNow)
-                    .Set(s => s.IdleExpiry, idleExpiry);
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error removing account from IdP session: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
+            var update = Builders<IdpSessionModel>.Update
+                .PullFilter(s => s.Accounts, a => a.UserId == userId && a.TenantId == tenantId)
+                .Set(s => s.LastActivityAt, DateTime.UtcNow)
+                .Set(s => s.IdleExpiry, idleExpiry);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> UpdateActivityAsync(string sessionId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
-                var update = Builders<IdpSessionModel>.Update
-                    .Set(s => s.LastActivityAt, DateTime.UtcNow)
-                    .Set(s => s.IdleExpiry, idleExpiry);
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error updating IdP session activity: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            var idleExpiry = DateTime.UtcNow.Add(GetIdpSessionIdleTimeout());
+            var update = Builders<IdpSessionModel>.Update
+                .Set(s => s.LastActivityAt, DateTime.UtcNow)
+                .Set(s => s.IdleExpiry, idleExpiry);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> RevokeAsync(string sessionId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                var update = Builders<IdpSessionModel>.Update.Set(s => s.RevokedAt, DateTime.UtcNow);
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error revoking IdP session: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            var update = Builders<IdpSessionModel>.Update.Set(s => s.RevokedAt, DateTime.UtcNow);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> DeleteAsync(string sessionId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
-                var update = Builders<IdpSessionModel>.Update.Set(s => s.RevokedAt, DateTime.UtcNow);
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error soft deleting IdP session: {sessionId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.Eq(s => s.SessionId, sessionId);
+            var update = Builders<IdpSessionModel>.Update.Set(s => s.RevokedAt, DateTime.UtcNow);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<IEnumerable<IdpSessionModel>> GetByUserAsync(string userId, string tenantId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
-                var filter = Builders<IdpSessionModel>.Filter.And(
-                    Builders<IdpSessionModel>.Filter.ElemMatch(s => s.Accounts, 
-                        Builders<IdpSessionAccount>.Filter.Eq(a => a.UserId, userId)),
-                    Builders<IdpSessionModel>.Filter.Eq(s => s.TenantId, tenantId)
-                );
-                return await collection.Find(filter).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching IdP sessions for user: {userId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<IdpSessionModel>("IdpSessions");
+            var filter = Builders<IdpSessionModel>.Filter.And(
+                Builders<IdpSessionModel>.Filter.ElemMatch(s => s.Accounts,
+                    Builders<IdpSessionAccount>.Filter.Eq(a => a.UserId, userId)),
+                Builders<IdpSessionModel>.Filter.Eq(s => s.TenantId, tenantId)
+            );
+            return await collection.Find(filter).ToListAsync();
         }
 
         private static TimeSpan GetIdpSessionIdleTimeout()
@@ -180,4 +116,3 @@ namespace Authentication.DomainService.Oidc.Repositories
         }
     }
 }
-

--- a/server/Authentication.DomainService/Oidc/Repositories/RefreshTokenRepository.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/RefreshTokenRepository.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Oidc.Repositories
 {
-    public class RefreshTokenRepository : IRefreshTokenRepository
+    public sealed class RefreshTokenRepository : IRefreshTokenRepository
     {
         private readonly IDbContextProvider _dbContextProvider;
         private readonly IAuthenticationRepository _authenticationRepository;
@@ -29,129 +29,72 @@ namespace Authentication.DomainService.Oidc.Repositories
 
         public async Task<string> CreateAsync(RefreshTokenModel token)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                await collection.InsertOneAsync(token);
-                _logger.LogInformation($"Refresh token created for user {token.UserId}, client {token.ClientId}");
-                return token.TokenId;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error creating refresh token");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            await collection.InsertOneAsync(token);
+            _logger.LogInformation("Refresh token created for user {UserId}, client {ClientId}", token.UserId, token.ClientId);
+            return token.TokenId;
         }
 
         public async Task<RefreshTokenModel> GetByTokenIdAsync(string tokenId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
-                return await collection.Find(filter).FirstOrDefaultAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching refresh token: {tokenId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
+            return await collection.Find(filter).FirstOrDefaultAsync();
         }
 
         public async Task<IEnumerable<RefreshTokenModel>> GetByUserAsync(string userId, string tenantId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.And(
-                    Builders<RefreshTokenModel>.Filter.Eq(t => t.UserId, userId),
-                    Builders<RefreshTokenModel>.Filter.Eq(t => t.TenantId, tenantId)
-                );
-                return await collection.Find(filter).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching refresh tokens for user: {userId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.And(
+                Builders<RefreshTokenModel>.Filter.Eq(t => t.UserId, userId),
+                Builders<RefreshTokenModel>.Filter.Eq(t => t.TenantId, tenantId)
+            );
+            return await collection.Find(filter).ToListAsync();
         }
 
         public async Task<bool> RevokeByTokenIdAsync(string tokenId, string reason)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
-                var update = Builders<RefreshTokenModel>.Update
-                    .Set(t => t.IsRevoked, true)
-                    .Set(t => t.RevokeReason, reason)
-                    .Set(t => t.RevokedAt, DateTime.UtcNow);
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
+            var update = Builders<RefreshTokenModel>.Update
+                .Set(t => t.IsRevoked, true)
+                .Set(t => t.RevokeReason, reason)
+                .Set(t => t.RevokedAt, DateTime.UtcNow);
 
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error revoking refresh token: {tokenId}");
-                throw;
-            }
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> UpdateSlidingExpiryAsync(string tokenId)
         {
-            try
-            {
-                var authConfiguration = await _authenticationRepository.GetAuthenticationConfigurationAsync();
-                var slidingMinutes = Math.Max(authConfiguration?.RefreshTokenValidForNumberMinutes ?? IdentityConfiguration.DefaultRefreshTokenValidForNumberMinutes, 1);
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
-                var update = Builders<RefreshTokenModel>.Update
-                    .Set(t => t.SlidingExpiry, DateTime.UtcNow.AddMinutes(slidingMinutes));
+            var authConfiguration = await _authenticationRepository.GetAuthenticationConfigurationAsync();
+            var slidingMinutes = Math.Max(authConfiguration?.RefreshTokenValidForNumberMinutes ?? IdentityConfiguration.DefaultRefreshTokenValidForNumberMinutes, 1);
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
+            var update = Builders<RefreshTokenModel>.Update
+                .Set(t => t.SlidingExpiry, DateTime.UtcNow.AddMinutes(slidingMinutes));
 
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error updating sliding expiry: {tokenId}");
-                throw;
-            }
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<bool> DeleteAsync(string tokenId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
-                var update = Builders<RefreshTokenModel>.Update
-                    .Set(t => t.IsRevoked, true)
-                    .Set(t => t.RevokedAt, DateTime.UtcNow);
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.Eq(t => t.TokenId, tokenId);
+            var update = Builders<RefreshTokenModel>.Update
+                .Set(t => t.IsRevoked, true)
+                .Set(t => t.RevokedAt, DateTime.UtcNow);
 
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error soft deleting refresh token: {tokenId}");
-                throw;
-            }
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         public async Task<IEnumerable<RefreshTokenModel>> GetExpiredAsync()
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
-                var filter = Builders<RefreshTokenModel>.Filter.Lt(t => t.AbsoluteExpiry, DateTime.UtcNow);
-                return await collection.Find(filter).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error fetching expired refresh tokens");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<RefreshTokenModel>("IdpRefreshTokens");
+            var filter = Builders<RefreshTokenModel>.Filter.Lt(t => t.AbsoluteExpiry, DateTime.UtcNow);
+            return await collection.Find(filter).ToListAsync();
         }
     }
 }
-

--- a/server/Authentication.DomainService/Oidc/Repositories/TokenRevocationRepository.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/TokenRevocationRepository.cs
@@ -9,7 +9,7 @@ namespace Authentication.DomainService.Oidc.Repositories
     /// Implements RFC 7009 Token Revocation and RFC 7662 Token Introspection
     /// Maintains JTI (JWT ID) blacklist for immediate token revocation
     /// </summary>
-    public class TokenRevocationRepository : ITokenRevocationRepository
+    public sealed class TokenRevocationRepository : ITokenRevocationRepository
     {
         private readonly IDbContextProvider _dbContextProvider;
         private readonly ILogger<TokenRevocationRepository> _logger;
@@ -31,26 +31,18 @@ namespace Authentication.DomainService.Oidc.Repositories
         /// </summary>
         public async Task<bool> RevokeTokenAsync(string jti, string userId, string reason, DateTime expiresAt)
         {
-            try
+            var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
+            var model = new TokenRevocationModel
             {
-                var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
-                var model = new TokenRevocationModel
-                {
-                    Jti = jti,
-                    UserId = userId,
-                    RevokedAt = DateTime.UtcNow,
-                    RevokeReason = reason,
-                    ExpiresAt = expiresAt
-                };
-                await collection.InsertOneAsync(model);
-                _logger.LogInformation($"Token revoked: {jti}, reason: {reason}");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error revoking token: {jti}");
-                throw;
-            }
+                Jti = jti,
+                UserId = userId,
+                RevokedAt = DateTime.UtcNow,
+                RevokeReason = reason,
+                ExpiresAt = expiresAt
+            };
+            await collection.InsertOneAsync(model);
+            _logger.LogInformation("Token revoked: {Jti}, reason: {Reason}", jti, reason);
+            return true;
         }
 
         /// <summary>
@@ -58,18 +50,10 @@ namespace Authentication.DomainService.Oidc.Repositories
         /// </summary>
         public async Task<bool> IsRevokedAsync(string jti)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
-                var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
-                var result = await collection.Find(filter).FirstOrDefaultAsync();
-                return result != null;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error checking token revocation: {jti}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
+            var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
+            var result = await collection.Find(filter).FirstOrDefaultAsync();
+            return result != null;
         }
 
         /// <summary>
@@ -77,22 +61,14 @@ namespace Authentication.DomainService.Oidc.Repositories
         /// </summary>
         public async Task<bool> DeleteAsync(string jti)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
-                var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
-                var update = Builders<TokenRevocationModel>.Update
-                    .Set(t => t.IsDeleted, true)
-                    .Set(t => t.DeletedAt, DateTime.UtcNow);
+            var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
+            var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
+            var update = Builders<TokenRevocationModel>.Update
+                .Set(t => t.IsDeleted, true)
+                .Set(t => t.DeletedAt, DateTime.UtcNow);
 
-                var result = await collection.UpdateOneAsync(filter, update);
-                return result.ModifiedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error soft deleting revocation record: {jti}");
-                throw;
-            }
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount > 0;
         }
 
         /// <summary>
@@ -100,17 +76,9 @@ namespace Authentication.DomainService.Oidc.Repositories
         /// </summary>
         public async Task<TokenRevocationModel> GetRevocationDetailsAsync(string jti)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
-                var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
-                return await collection.Find(filter).FirstOrDefaultAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching revocation details: {jti}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
+            var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.Jti, jti);
+            return await collection.Find(filter).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -118,21 +86,13 @@ namespace Authentication.DomainService.Oidc.Repositories
         /// </summary>
         public async Task<IEnumerable<TokenRevocationModel>> GetRevokedTokensByUserAsync(string userId)
         {
-            try
-            {
-                var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
-                var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.UserId, userId);
-                return await collection.Find(filter).SortByDescending(t => t.RevokedAt).ToListAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error fetching revoked tokens for user: {userId}");
-                throw;
-            }
+            var collection = GetDatabase().GetCollection<TokenRevocationModel>("IdpRevokedTokens");
+            var filter = Builders<TokenRevocationModel>.Filter.Eq(t => t.UserId, userId);
+            return await collection.Find(filter).SortByDescending(t => t.RevokedAt).ToListAsync();
         }
     }
 
-    public class TokenRevocationModel
+    public sealed class TokenRevocationModel
     {
         public string? Id { get; set; } // MongoDB ObjectId
         public string? Jti { get; set; } // JWT ID (unique token identifier)
@@ -144,4 +104,3 @@ namespace Authentication.DomainService.Oidc.Repositories
         public DateTime DeletedAt { get; set; } // Soft delete timestamp
     }
 }
-

--- a/server/Authentication.DomainService/Oidc/Repositories/TokenRevocationService.cs
+++ b/server/Authentication.DomainService/Oidc/Repositories/TokenRevocationService.cs
@@ -9,7 +9,7 @@ namespace Authentication.DomainService.Oidc.Repositories
     /// Token Revocation Service Implementation
     /// Implements RFC 7009 (Token Revocation) and RFC 7662 (Token Introspection)
     /// </summary>
-    public class TokenRevocationService : ITokenRevocationService
+    public sealed class TokenRevocationService : ITokenRevocationService
     {
         private readonly ITokenRevocationRepository _revocationRepo;
         private readonly IRefreshTokenRepository _refreshTokenRepo;
@@ -166,9 +166,9 @@ namespace Authentication.DomainService.Oidc.Repositories
 
                 // Extract claims from token
                 var handler = new JwtSecurityTokenHandler();
-                var token_obj = handler.ReadJwtToken(token);
+                var tokenObj = handler.ReadJwtToken(token);
 
-                if (!IsClientAuthorizedForAccessToken(token_obj, clientId))
+                if (!IsClientAuthorizedForAccessToken(tokenObj, clientId))
                 {
                     return new TokenIntrospectionResult
                     {
@@ -176,7 +176,7 @@ namespace Authentication.DomainService.Oidc.Repositories
                     };
                 }
 
-                var expiryTime = token_obj.ValidTo;
+                var expiryTime = tokenObj.ValidTo;
                 var isExpired = expiryTime < DateTime.UtcNow;
 
                 if (isExpired)
@@ -194,13 +194,13 @@ namespace Authentication.DomainService.Oidc.Repositories
                 {
                     Active = true,
                     Jti = jti,
-                    Sub = token_obj.Subject,
-                    ClientId = token_obj.Audiences.FirstOrDefault(),
-                    Iss = token_obj.Issuer,
-                    Iat = new DateTimeOffset(token_obj.IssuedAt).ToUnixTimeSeconds(),
+                    Sub = tokenObj.Subject,
+                    ClientId = tokenObj.Audiences.FirstOrDefault(),
+                    Iss = tokenObj.Issuer,
+                    Iat = new DateTimeOffset(tokenObj.IssuedAt).ToUnixTimeSeconds(),
                     Exp = new DateTimeOffset(expiryTime).ToUnixTimeSeconds(),
                     TokenType = "Bearer",
-                    Scope = ExtractScopeFromToken(token_obj)
+                    Scope = ExtractScopeFromToken(tokenObj)
                 };
             }
             catch (Exception ex)

--- a/server/Authentication.DomainService/Oidc/Services/IdpSessionService.cs
+++ b/server/Authentication.DomainService/Oidc/Services/IdpSessionService.cs
@@ -27,7 +27,7 @@ namespace Authentication.DomainService.Oidc.Services
         Task<IEnumerable<IdpSessionModel>> GetUserSessionsAsync(string userId, string tenantId);
     }
 
-    public class IdpSessionService : IIdpSessionService
+    public sealed class IdpSessionService : IIdpSessionService
     {
         private readonly IIdpSessionRepository _sessionRepo;
         private readonly IAuditLogRepository _auditLogRepo;

--- a/server/Authentication.DomainService/Oidc/Services/OidcCallbackHandler.cs
+++ b/server/Authentication.DomainService/Oidc/Services/OidcCallbackHandler.cs
@@ -14,7 +14,7 @@ namespace Authentication.DomainService.Oidc.Services
         Task<OidcCallbackResult> HandleCallbackAsync(string code, string state);
     }
 
-    public class OidcCallbackResult
+    public sealed class OidcCallbackResult
     {
         public bool IsSuccess { get; set; }
         public string? AccessToken { get; set; }
@@ -39,7 +39,7 @@ namespace Authentication.DomainService.Oidc.Services
         public string? TenantId { get; set; }
     }
 
-    public class OidcCallbackHandler : IOidcCallbackHandler
+    public sealed class OidcCallbackHandler : IOidcCallbackHandler
     {
         private readonly ILogger<OidcCallbackHandler> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/Oidc/Services/OidcServices.cs
+++ b/server/Authentication.DomainService/Oidc/Services/OidcServices.cs
@@ -58,7 +58,7 @@ public sealed class OidcSigningKeyMaterial
     public SigningCredentials SigningCredentials { get; }
 }
 
-public class TokenGenerationService : ITokenGenerationService
+public sealed class TokenGenerationService : ITokenGenerationService
 {
     private readonly OidcSigningKeyMaterial _keyMaterial;
     private readonly ITenants _tenants;
@@ -345,7 +345,7 @@ public class TokenGenerationService : ITokenGenerationService
     }
 }
 
-public class PkceService : IPkceService
+public sealed class PkceService : IPkceService
 {
     public Task<bool> ValidateVerifierAsync(string codeChallenge, string codeVerifier, string? codeChallengeMethod)
     {
@@ -361,7 +361,7 @@ public class PkceService : IPkceService
     }
 }
 
-public class DiscoveryService : IDiscoveryService
+public sealed class DiscoveryService : IDiscoveryService
 {
     private const string DiscoveryCachePrefix = "oidcdiscovery::";
     private const string OAuthCachePrefix = "oidcoauth::";
@@ -543,7 +543,7 @@ public class DiscoveryService : IDiscoveryService
     }
 }
 
-public class JwksService : IJwksService
+public sealed class JwksService : IJwksService
 {
     private static readonly HttpClient PublicCertificateHttpClient = new();
 

--- a/server/Authentication.DomainService/Oidc/Validation/AuthorizeRequestValidator.cs
+++ b/server/Authentication.DomainService/Oidc/Validation/AuthorizeRequestValidator.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Authentication.DomainService.Oidc.Validation
 {
-    public class AuthorizeRequestValidator
+    public sealed class AuthorizeRequestValidator
     {
         public AuthorizeValidationResult Validate(AuthorizeRequest request)
         {
@@ -66,7 +66,7 @@ namespace Authentication.DomainService.Oidc.Validation
         }
     }
 
-    public class AuthorizeValidationResult
+    public sealed class AuthorizeValidationResult
     {
         public bool IsValid { get; set; }
         public List<string> Errors { get; set; } = new List<string>();

--- a/server/Authentication.DomainService/Shared/Dtos/RefreshTokenCache.cs
+++ b/server/Authentication.DomainService/Shared/Dtos/RefreshTokenCache.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Dtos
 {
-    public class RefreshTokenCache
+    public sealed class RefreshTokenCache
     {
         public string? RefreshToken { get; set; }
         public string? TenantId { get; set; }

--- a/server/Authentication.DomainService/Shared/Dtos/UserAuthenticationTimelineEvent.cs
+++ b/server/Authentication.DomainService/Shared/Dtos/UserAuthenticationTimelineEvent.cs
@@ -2,7 +2,7 @@ using Iam.DomainService.Dtos;
 
 namespace Authentication.DomainService.Dtos
 {
-    public class UserAuthenticationTimelineEvent
+    public sealed class UserAuthenticationTimelineEvent
     {
         public DeviceInformation? DeviceInformation { get; set; }
         public string? IpAddresses { get; set; }

--- a/server/Authentication.DomainService/Shared/Entities/BiometricCredential.cs
+++ b/server/Authentication.DomainService/Shared/Entities/BiometricCredential.cs
@@ -8,7 +8,7 @@ namespace Authentication.DomainService.Entities
         public string? PhysicalAddress { get; set; }
         public bool IsActive { get; set; }
         public string? BiometricId { get; set; }
-        public string? BiometriKey { get; set; }
+        public string? BiometricKey { get; set; }
         public BiometricType BiometricType { get; set; }
         public string? DeviceInformation { get; set; }
     }

--- a/server/Authentication.DomainService/Shared/Entities/IdentityConfiguration.cs
+++ b/server/Authentication.DomainService/Shared/Entities/IdentityConfiguration.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Authentication.DomainService.Entities
 {
     [BsonIgnoreExtraElements]
-    public class IdentityConfiguration
+    public sealed class IdentityConfiguration
     {
         public const int DefaultAccessTokenValidForNumberMinutes = 7;
         public const int DefaultRefreshTokenValidForNumberMinutes = 30;

--- a/server/Authentication.DomainService/Shared/Entities/IdentityEvent.cs
+++ b/server/Authentication.DomainService/Shared/Entities/IdentityEvent.cs
@@ -5,7 +5,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Authentication.DomainService.Entities
 {
     [BsonIgnoreExtraElements]
-    public class IdentityEvent
+    public sealed class IdentityEvent
     {
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]

--- a/server/Authentication.DomainService/Shared/Entities/IdentitySession.cs
+++ b/server/Authentication.DomainService/Shared/Entities/IdentitySession.cs
@@ -5,7 +5,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Authentication.DomainService.Entities
 {
     [BsonIgnoreExtraElements]
-    public class IdentitySession
+    public sealed class IdentitySession
     {
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]

--- a/server/Authentication.DomainService/Shared/Entities/ImpersonationSession.cs
+++ b/server/Authentication.DomainService/Shared/Entities/ImpersonationSession.cs
@@ -1,9 +1,9 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace Authentication.DomainService.Entities
 {
     [BsonIgnoreExtraElements]
-    public class ImpersonationSession
+    public sealed class ImpersonationSession
     {
         [BsonId]
         public string Id { get; set; } = Guid.NewGuid().ToString();

--- a/server/Authentication.DomainService/Shared/Entities/TenantCertificate.cs
+++ b/server/Authentication.DomainService/Shared/Entities/TenantCertificate.cs
@@ -3,7 +3,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Authentication.DomainService.Entities
 {
     [BsonIgnoreExtraElements]
-    public class TenantCertificate
+    public sealed class TenantCertificate
     {
         [BsonId]
         public string? ItemId { get; set; }

--- a/server/Authentication.DomainService/Shared/RequestModel/AcknowledgeRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/AcknowledgeRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Shared.RequestModel
 {
-    public class AcknowledgeRequest
+    public sealed class AcknowledgeRequest
     {
         public string? ClientId { get; set; }
         public string? RedirectUri { get; set; }

--- a/server/Authentication.DomainService/Shared/RequestModel/DeleteSsoCredentialRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/DeleteSsoCredentialRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.RequestModel
 {
-    public class DeleteSsoCredentialRequest
+    public sealed class DeleteSsoCredentialRequest
     {
         public string? ItemId { get; set; }
     }

--- a/server/Authentication.DomainService/Shared/RequestModel/GenerateUserCodeRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/GenerateUserCodeRequest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Authentication.DomainService.Shared.RequestModel
 {
-    public class GenerateUserCodeRequest
+    public sealed class GenerateUserCodeRequest
     {
         public string? ClientId { get; set; }
         public int CodeTtlInMinute { get; set; } = 10080; // default 7 days 

--- a/server/Authentication.DomainService/Shared/RequestModel/GetAllClientCredentialsRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/GetAllClientCredentialsRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Shared.RequestModel
 {
-    public class GetAllClientCredentialsRequest
+    public sealed class GetAllClientCredentialsRequest
     {
 
     }

--- a/server/Authentication.DomainService/Shared/RequestModel/GetOIDCClientRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/GetOIDCClientRequest.cs
@@ -3,17 +3,17 @@ using Authentication.DomainService.Entities;
 
 namespace Authentication.DomainService.RequestModel
 {
-    public class GetOIDCClientRequest
+    public sealed class GetOIDCClientRequest
     {
         public string? ClientId { get; set; }    
     }
 
-    public class GetOIDCClientsRequest
+    public sealed class GetOIDCClientsRequest
     {
 
     }
 
-    public class DeleteOIDCClientRequest
+    public sealed class DeleteOIDCClientRequest
     {
         public string? ItemId { get; set; }
     }

--- a/server/Authentication.DomainService/Shared/RequestModel/GetSsoCredentialRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/GetSsoCredentialRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.RequestModel
 {
-    public class GetSsoCredentialRequest
+    public sealed class GetSsoCredentialRequest
     {
         public string? ItemId { get; set; }
     }

--- a/server/Authentication.DomainService/Shared/RequestModel/GetSsoCredentialsRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/GetSsoCredentialsRequest.cs
@@ -1,7 +1,7 @@
 
 namespace Authentication.DomainService.RequestModel
 {
-    public class GetSsoCredentialsRequest
+    public sealed class GetSsoCredentialsRequest
     {
     }
 }

--- a/server/Authentication.DomainService/Shared/RequestModel/ImpersonateRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/ImpersonateRequest.cs
@@ -1,8 +1,8 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Authentication.DomainService.Shared.RequestModel
 {
-    public class ImpersonateRequest
+    public sealed class ImpersonateRequest
     {
         [JsonPropertyName("targeted_tenant_id")]
         public string TargetTenantId { get; set; }
@@ -20,7 +20,7 @@ namespace Authentication.DomainService.Shared.RequestModel
 
     }
 
-    public class StopImpersonationRequest
+    public sealed class StopImpersonationRequest
     {
         [JsonPropertyName("refresh_token")]
         public string? RefreshToken { get; set; }
@@ -29,13 +29,13 @@ namespace Authentication.DomainService.Shared.RequestModel
         public string? ImpersonationId { get; set; }
     }
 
-    public class ImpersonateResponse
+    public sealed class ImpersonateResponse
     {
         public bool impersonation_mode { get; set; } = true;
         public bool org_switched { get; set; } = false;
     }
 
-    public class StopImpersonationResponse
+    public sealed class StopImpersonationResponse
     {
         public bool impersonation_mode { get; set; } = false;
         public string? error { get; set; }

--- a/server/Authentication.DomainService/Shared/RequestModel/SaveClientCredentialRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/SaveClientCredentialRequest.cs
@@ -1,13 +1,13 @@
 namespace Authentication.DomainService.Shared.RequestModel
 {
-    public class SaveClientCredentialRequest
+    public sealed class SaveClientCredentialRequest
     {
         public string? Name { get; set; }
         public List<string> Roles { get; set; } = [];
         public Dictionary<string, List<string>> PermissionsByOrg { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 
-    public class DeleteClientCredentialRequest
+    public sealed class DeleteClientCredentialRequest
     {
         public string? ItemId { get; set; }
     }

--- a/server/Authentication.DomainService/Shared/RequestModel/SaveOIDCClientRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/SaveOIDCClientRequest.cs
@@ -2,7 +2,7 @@ using Iam.DomainService.Entities;
 
 namespace Authentication.DomainService.RequestModel
 {
-    public class SaveOIDCClientRequest
+    public sealed class SaveOIDCClientRequest
     {
         public List<string> RedirectUris { get; set; } = new();
         public List<string> PostLogoutRedirectUris { get; set; } = new();

--- a/server/Authentication.DomainService/Shared/RequestModel/SaveSsoCredentialRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/SaveSsoCredentialRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.Shared
 {
-    public class SaveSsoCredentialRequest
+    public sealed class SaveSsoCredentialRequest
     {
         public string? Provider { get; set; }
         public string? Audience { get; set; }

--- a/server/Authentication.DomainService/Shared/RequestModel/UpdateSsoCredentialStatusRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/UpdateSsoCredentialStatusRequest.cs
@@ -1,6 +1,6 @@
 namespace Authentication.DomainService.RequestModel
 {
-    public class UpdateSsoCredentialStatusRequest
+    public sealed class UpdateSsoCredentialStatusRequest
     {
         public string? ItemId { get; set; }
         public bool IsEnabled { get; set; }

--- a/server/Authentication.DomainService/Shared/ResponseModel/GetUserCodesByUserIdResponse.cs
+++ b/server/Authentication.DomainService/Shared/ResponseModel/GetUserCodesByUserIdResponse.cs
@@ -2,7 +2,7 @@ using Blocks.Genesis;
 using Authentication.DomainService.Entities;
 namespace Authentication.DomainService.Shared.ResponseModel
 {
-    public class GetUserCodesByUserIdResponse
+    public sealed class GetUserCodesByUserIdResponse
     {
         public string? ItemId { get; set; }
         public DateTime CreatedDate { get; set; }

--- a/server/Authentication.DomainService/Shared/Services/AuthenticationDomainService.cs
+++ b/server/Authentication.DomainService/Shared/Services/AuthenticationDomainService.cs
@@ -19,7 +19,7 @@ using Iam.DomainService.Dtos;
 
 namespace Authentication.DomainService.Services
 {
-    public class AuthenticationDomainService : IAuthenticationDomainService
+    public sealed class AuthenticationDomainService : IAuthenticationDomainService
     {
         private readonly IMessageClient _messageClient;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/Shared/Services/AuthenticationRepository.cs
+++ b/server/Authentication.DomainService/Shared/Services/AuthenticationRepository.cs
@@ -9,7 +9,7 @@ using MongoDB.Driver;
 
 namespace Authentication.DomainService.Services
 {
-    public class AuthenticationRepository : IAuthenticationRepository
+    public sealed class AuthenticationRepository : IAuthenticationRepository
     {
         private const string OidcClientRegistrationsCollectionName = "OidcClientRegistrations";
 
@@ -554,7 +554,7 @@ namespace Authentication.DomainService.Services
         public async Task<BiometricCredential> AuthenticateBiometricCredentialAsync(string biometricId, string biometricKey)
         {
             var collection = GetCollection<BiometricCredential>();
-            var filter = Builders<BiometricCredential>.Filter.Where(it => it.BiometricId == biometricId && it.BiometriKey == biometricId);
+            var filter = Builders<BiometricCredential>.Filter.Where(it => it.BiometricId == biometricId && it.BiometricKey == biometricKey);
             return await (await collection.FindAsync(filter)).FirstOrDefaultAsync();
         }
 

--- a/server/Authentication.DomainService/Shared/Services/ImpersonationFlowHelper.cs
+++ b/server/Authentication.DomainService/Shared/Services/ImpersonationFlowHelper.cs
@@ -1,4 +1,4 @@
-﻿using Authentication.DomainService.Entities;
+using Authentication.DomainService.Entities;
 using Authentication.DomainService.Services;
 using Blocks.Genesis;
 
@@ -17,7 +17,7 @@ namespace Authentication.DomainService.Shared.Services
 
     }
 
-    public class ImpersonationFlowHelper : IImpersonationFlowHelper
+    public sealed class ImpersonationFlowHelper : IImpersonationFlowHelper
     {
         private readonly IAuthenticationRepository _repository;
 

--- a/server/Authentication.DomainService/Shared/UnifiedTokenSessionService.cs
+++ b/server/Authentication.DomainService/Shared/UnifiedTokenSessionService.cs
@@ -12,7 +12,7 @@ using Authentication.DomainService.Oidc.Repositories;
 
 namespace Authentication.DomainService.Shared
 {
-    public class UnifiedTokenSessionService
+    public sealed class UnifiedTokenSessionService
     {
         private readonly ICacheClient _cacheClient;
         private readonly IAuthenticationDomainService _authenticationDomainService;

--- a/server/Authentication.DomainService/Worker/LogoutAllWorkerService.cs
+++ b/server/Authentication.DomainService/Worker/LogoutAllWorkerService.cs
@@ -8,7 +8,7 @@ using Authentication.DomainService.Oidc.Repositories;
 
 namespace Authentication.DomainService.Worker
 {
-    public class LogoutAllWorkerService : IConsumer<LogoutAllEvent>
+    public sealed class LogoutAllWorkerService : IConsumer<LogoutAllEvent>
     {
         private readonly ICacheClient _cacheClient;
         private readonly IAuthenticationRepository _authenticationRepository;

--- a/server/Authentication.DomainService/Worker/RefreshTokenWorkerService.cs
+++ b/server/Authentication.DomainService/Worker/RefreshTokenWorkerService.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 
 namespace Authentication.DomainService.Worker
 {
-    public class RefreshTokenWorkerService : IConsumer<RefreshTokenEvent>
+    public sealed class RefreshTokenWorkerService : IConsumer<RefreshTokenEvent>
     {
         private readonly ILogger<RefreshTokenWorkerService> _logger;
         private readonly IAuthenticationRepository _oAuthRepository;

--- a/server/Authentication.DomainService/Worker/UserAuthenticationTimelineWorkerService.cs
+++ b/server/Authentication.DomainService/Worker/UserAuthenticationTimelineWorkerService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Authentication.DomainService.Worker
 {
-    public class UserAuthenticationTimelineWorkerService : IConsumer<UserAuthenticationTimelineEvent>
+    public sealed class UserAuthenticationTimelineWorkerService : IConsumer<UserAuthenticationTimelineEvent>
     {
         private readonly ILogger<UserAuthenticationTimelineWorkerService> _logger;
         private readonly IAuthenticationRepository _authenticationRepository;


### PR DESCRIPTION
- Seal 83 non-sealed concrete classes (services, repos, providers, validators, DTOs)
- Rename typos: BiometriKey -> BiometricKey, ExpireIn -> ExpiresIn, Public_Cert_Cache_Prefix -> PublicCertCachePrefix, token_obj -> tokenObj, googleProvider/microsoftProvider -> GoogleProvider/MicrosoftProvider, KeyCloak -> Keycloak, remove KeyClock duplicate
- Remove 4 Console.WriteLine sites -> ILogger; log int truncation for refresh token reuse
- Remove 4 commented-code blocks (JwtAccessTokenProvider, ClientCredentialAuthorizationService, BYOSsoAuthorizationService, IdpService)
- Remove useless alias GetClientIp and no-op ternary "WARN":"WARN"
- Strip try/catch wrappers from 5 repositories (AuditLog, AuthorizationCode, IdpSession, RefreshToken, TokenRevocation); convert remaining logs to structured templates
- Fix sensitive logging: drop access-token log (BYOSsoLogInService), host-only Facebook URL log, 8-char fingerprint for refresh token
- Fix real bugs:
  * BiometricCredential lookup used wrong field and wrong value (BiometriKey==biometricId -> BiometricKey==biometricKey)
  * LinkedinLogInService UserInfoUrl missing '?' separator
  * FileSystemCertificateProvider: wire 'key' parameter via Path.Combine
  * MongodbCertificateProvider: log message "from MongoDB" (was "from file system")
  * OAuthError/SocialAuthorizationService(s/Base): grammar fixes
- Replace new HttpClient() with IHttpClientFactory in SaveSsoCredentialRequestValidator
- Replace ClientCredentialSecret != comparison with CryptographicOperations.FixedTimeEquals (SecretsMatch helper)