### PR TITLE
fix(auth): fallback to request client_id during impersonation

### DIFF
--- a/server/Authentication.DomainService/Authentication/AuthenticationService.cs
+++ b/server/Authentication.DomainService/Authentication/AuthenticationService.cs
@@ -1168,7 +1168,9 @@ namespace Authentication.DomainService.Authentication
             try
             {
 
-                var clientId = rootRefreshCache.ClientId;
+                var clientId = !string.IsNullOrWhiteSpace(rootRefreshCache.ClientId)
+                    ? rootRefreshCache.ClientId
+                    : request.ClientId;
                 if (string.IsNullOrWhiteSpace(clientId) || !await HasOidcClientConfigurationAsync(clientId))
                 {
                     return new ObjectResult(new

--- a/server/Authentication.DomainService/Shared/RequestModel/ImpersonateRequest.cs
+++ b/server/Authentication.DomainService/Shared/RequestModel/ImpersonateRequest.cs
@@ -18,6 +18,9 @@ namespace Authentication.DomainService.Shared.RequestModel
 
         public string? ImpersontingUserId { get; set; }
 
+        [JsonPropertyName("client_id")]
+        public string? ClientId {get; set;}
+
     }
 
     public sealed class StopImpersonationRequest


### PR DESCRIPTION
Ensure that `ClientId` is correctly retrieved during the impersonation process by falling back to the `request.ClientId` if the `rootRefreshCache` does not contain a value.

Additionally, add the `client_id` property to the `ImpersonateRequest` model to allow it to be passed in the request payload.