### PR TITLE
chore: clear technical, product, and architectural debt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,96 @@
+# EditorConfig — root of the repository
+# Encodes the naming and formatting conventions already in use across blocks-iam so
+# that violations surface at build time (see server/Directory.Build.props). Rules start
+# at "warning" severity so CI stays green; ratchet toward error later (see CONTRIBUTING.md).
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+# ---------------------------------------------------------------------------
+# C#
+# ---------------------------------------------------------------------------
+[*.cs]
+indent_size = 4
+
+# --- Symbol groups -----------------------------------------------------------
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, enum, delegate
+dotnet_naming_symbols.types.applicable_accessibilities = *
+
+dotnet_naming_symbols.public_members.applicable_kinds = property, method, event
+dotnet_naming_symbols.public_members.applicable_accessibilities = public, internal, protected, protected_internal
+
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+
+dotnet_naming_symbols.locals.applicable_kinds = local
+dotnet_naming_symbols.locals.applicable_accessibilities = *
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_symbols.async_methods.applicable_kinds = method
+dotnet_naming_symbols.async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.async_methods.required_modifiers = async
+
+# --- Naming styles -----------------------------------------------------------
+dotnet_naming_style.i_prefix.capitalization = pascal_case
+dotnet_naming_style.i_prefix.required_prefix = I
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+
+dotnet_naming_style.async_suffix.capitalization = pascal_case
+dotnet_naming_style.async_suffix.required_suffix = Async
+
+# --- Rules (warning severity — de-facto true today) --------------------------
+dotnet_naming_rule.interfaces_start_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_start_with_i.style = i_prefix
+dotnet_naming_rule.interfaces_start_with_i.severity = warning
+
+dotnet_naming_rule.types_are_pascal_case.symbols = types
+dotnet_naming_rule.types_are_pascal_case.style = pascal_case
+dotnet_naming_rule.types_are_pascal_case.severity = warning
+
+dotnet_naming_rule.public_members_are_pascal_case.symbols = public_members
+dotnet_naming_rule.public_members_are_pascal_case.style = pascal_case
+dotnet_naming_rule.public_members_are_pascal_case.severity = warning
+
+dotnet_naming_rule.parameters_are_camel_case.symbols = parameters
+dotnet_naming_rule.parameters_are_camel_case.style = camel_case
+dotnet_naming_rule.parameters_are_camel_case.severity = warning
+
+dotnet_naming_rule.locals_are_camel_case.symbols = locals
+dotnet_naming_rule.locals_are_camel_case.style = camel_case
+dotnet_naming_rule.locals_are_camel_case.severity = warning
+
+dotnet_naming_rule.private_fields_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_underscore.style = underscore_camel_case
+dotnet_naming_rule.private_fields_underscore.severity = warning
+
+dotnet_naming_rule.async_methods_end_with_async.symbols = async_methods
+dotnet_naming_rule.async_methods_end_with_async.style = async_suffix
+dotnet_naming_rule.async_methods_end_with_async.severity = suggestion
+
+# ---------------------------------------------------------------------------
+# TypeScript / JavaScript / JSON / YAML
+# ---------------------------------------------------------------------------
+[*.{ts,tsx,js,jsx,mjs,cjs}]
+indent_size = 2
+
+[*.{json,jsonc,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Blocks IAM
+
+This document captures the conventions that a linter or analyzer **cannot** check on its own.
+The mechanically enforceable rules live in `.editorconfig` (C# naming + formatting, surfaced at
+build time via `server/Directory.Build.props`) and `client/.eslintrc.cjs` (TypeScript naming).
+Those start at **warning** severity so the build stays green today; the plan is to fix drift and
+ratchet toward **error** over time. Do not turn on `TreatWarningsAsErrors` until the warning
+backlog is cleared.
+
+## Product naming
+
+- The product is **Blocks IAM**. Use that name on every user-facing surface (sign-in, consent,
+  account selection, activation, account screens).
+- **Blocks Cloud** is not this product and must not appear on IAM-owned screens.
+- **IdP** refers to *external* or tenant-created identity providers (Entra, Google, Okta, Auth0,
+  customer OIDC), never to this product.
+
+## HTTP routing
+
+- Routes are lower-case, hyphenated, and resource-oriented. Collections are plural nouns
+  (`/iam/users`, `/oidc-clients`, `/refresh-tokens`).
+- Prefer verbs implied by the HTTP method over verb segments: `GET` a collection or item,
+  `POST` to create, `PUT`/`PATCH` to update, `DELETE` to remove. Where an explicit action is
+  unavoidable, use `{resource}/{id}/{action}` (e.g. `refresh-tokens/{tokenId}/revoke`).
+- Route parameters are camelCase (`{tenantId}`, `{clientId}`). Keep RFC-defined names verbatim
+  where a spec requires them (`device_authorization`); do not invent new snake_case names.
+- **Renames are backward compatible.** When a route changes, add the new route and keep the old
+  one as a documented compatibility alias (mark it deprecated); never delete a live route.
+
+## Controller actions
+
+- Action method names are noun-specific and match the route + domain concept
+  (`GetAuthenticationConfiguration`, `CreateUser`, `AssignRolePermissions`, `GetMfaConfig`).
+  Avoid bare verbs (`Get`, `Update`, `Upsert`) and names that contradict their route.
+- Do not declare request parameters that the action never reads. A parameter published in the
+  signature appears in OpenAPI as a supported filter; if it does nothing, that is a lie to callers.
+
+## Response envelope
+
+- Application endpoints return a typed `Task<ActionResult<TResponse>>` using the shared response
+  envelope. The success flag is **`IsSuccess`** — never `Success`. Do not introduce new anonymous
+  error shapes or `Dictionary<string, object>` responses; model an explicit DTO instead.
+- OAuth/OIDC endpoints are a documented exception: they keep the RFC `{ error, error_description }`
+  shape. Keep those isolated from the application envelope.
+
+## DTO / model naming
+
+- Inbound payloads are `*Request`; outbound payloads are `*Response`. The repo standard is
+  `*Request` / `*Response`, not `*Dto` or `*Payload`.
+- Put request/response models in a `RequestModel` / `ResponseModel` (or `Models`) folder, not
+  nested inside a controller class.
+- Protocol-specific OAuth/OIDC payload names stay isolated and keep their spec names.
+
+## Permission-scope grammar
+
+- Scopes follow `service.controller.action`, e.g. `blocks-iam::mfa::mutate-mfa-configs`.
+- The area segment should match the owning controller (`mfa`, `security`, `oidc-clients`), not a
+  catch-all `iam`, unless an exception is explicitly documented.
+- **Scopes are IAM-grant-breaking.** Changing a scope string can revoke access. A scope change is
+  a data/rollout change (permission seeding, role-template updates, frontend checks) — never a
+  silent code edit. Coordinate before touching one.
+
+## C# specifics
+
+- Interfaces are `I`-prefixed; types and public members are PascalCase; parameters and locals are
+  camelCase; private fields are `_camelCase`.
+- `Task`-returning methods carry the `Async` suffix.
+
+## TypeScript specifics
+
+- Filenames are kebab-case. Hooks are `use-*.ts(x)`; services are `*.service.ts`. Prefer named
+  exports. (These filename rules are documented here rather than lint-enforced to avoid pulling in
+  an extra ESLint plugin; enforcement can be added later with `eslint-plugin-unicorn`.)
+- Types and React components are PascalCase; variables, functions, and parameters are camelCase.
+
+## Cross-repo alignment
+
+These conventions are intended to be shared across the five Blocks repos. When you change a
+convention here, raise the matching change in the sibling repos so the standard does not fork.

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -41,6 +41,50 @@ module.exports = {
         caughtErrorsIgnorePattern: "^_",
       },
     ],
+    // Naming conventions (see CONTRIBUTING.md). Authored to reflect the style already in
+    // use so it lands green; severity is "warn" and will be ratcheted toward "error" later.
+    // Filename conventions (kebab-case, use-* hooks, *.service.ts) are documented in
+    // CONTRIBUTING.md; enforcing them in-lint needs eslint-plugin-unicorn, deferred here to
+    // avoid adding a dependency in this change.
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        selector: "default",
+        format: ["camelCase"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+      {
+        selector: "variable",
+        format: ["camelCase", "PascalCase", "UPPER_CASE"],
+        leadingUnderscore: "allow",
+      },
+      {
+        selector: "parameter",
+        format: ["camelCase", "PascalCase"],
+        leadingUnderscore: "allow",
+      },
+      {
+        selector: "function",
+        format: ["camelCase", "PascalCase"],
+      },
+      {
+        selector: "typeLike",
+        format: ["PascalCase"],
+      },
+      {
+        selector: "enumMember",
+        format: ["camelCase", "PascalCase", "UPPER_CASE"],
+      },
+      {
+        selector: "property",
+        format: null,
+      },
+      {
+        selector: "import",
+        format: ["camelCase", "PascalCase"],
+      },
+    ],
   },
   ignorePatterns: ["node_modules/", "dist/"],
 };

--- a/client/app/idp/authentication/pages/login/signin.tsx
+++ b/client/app/idp/authentication/pages/login/signin.tsx
@@ -109,7 +109,7 @@ export const Signin = ({ ssoError, mode = "default", oidcContext }: SigninProps)
   return (
     <Card className="flex h-full flex-col rounded border-solid border-background shadow-none md:min-w-[448px] md:border-[#95ADC4] lg:max-w-md">
       <CardHeader className="text-center">
-        <CardTitle className="text-3xl">Blocks Cloud</CardTitle>
+        <CardTitle className="text-3xl">Blocks IAM</CardTitle>
         <CardDescription className="text-xl text-foreground">Log in</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col justify-between">
@@ -236,7 +236,7 @@ export const Signin = ({ ssoError, mode = "default", oidcContext }: SigninProps)
 //   return (
 //     <Card className="flex h-full flex-col rounded border-solid border-background shadow-none md:min-w-[448px] md:border-[#95ADC4] lg:max-w-md">
 //       <CardHeader className="text-center">
-//         <CardTitle className="text-3xl">Blocks Cloud</CardTitle>
+//         <CardTitle className="text-3xl">Blocks IAM</CardTitle>
 //         <CardDescription className="text-xl text-foreground">Log in</CardDescription>
 //       </CardHeader>
 //       <CardContent className="flex flex-1 flex-col justify-between">

--- a/client/app/idp/authentication/pages/oidc/oidc-account-selector.tsx
+++ b/client/app/idp/authentication/pages/oidc/oidc-account-selector.tsx
@@ -44,7 +44,7 @@ export const OidcAccountSelector = ({ accounts, onAccountSelect, isLoading = fal
     return (
       <Card className="flex h-full flex-col rounded border-solid border-background shadow-none md:min-w-[448px] md:border-[#95ADC4] lg:max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-3xl">Blocks Cloud</CardTitle>
+          <CardTitle className="text-3xl">Blocks IAM</CardTitle>
           <CardDescription className="text-xl text-foreground">Select Account</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-1 flex-col items-center justify-center">
@@ -57,7 +57,7 @@ export const OidcAccountSelector = ({ accounts, onAccountSelect, isLoading = fal
   return (
     <Card className="flex h-full flex-col rounded border-solid border-background shadow-none md:min-w-[448px] md:border-[#95ADC4] lg:max-w-md">
       <CardHeader className="text-center">
-        <CardTitle className="text-3xl">Blocks Cloud</CardTitle>
+        <CardTitle className="text-3xl">Blocks IAM</CardTitle>
         <CardDescription className="text-xl text-foreground">Select Account</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col justify-between">

--- a/client/app/idp/authentication/pages/oidc/permission.tsx
+++ b/client/app/idp/authentication/pages/oidc/permission.tsx
@@ -105,7 +105,7 @@ export const OIDCPermissionScreen = () => {
           )}
         </div>
         <CardDescription className="mt-3 text-lg text-foreground">
-          You&apos;re about to connect your Blocks Account to Blocks Cloud
+          You&apos;re about to connect your Blocks Account to Blocks IAM
         </CardDescription>
       </CardHeader>
       <CardContent className="mt-2 flex flex-1 flex-col justify-between">
@@ -119,7 +119,7 @@ export const OIDCPermissionScreen = () => {
             </ul>
           </div>
           <div className="my-4 text-left text-sm text-foreground">
-            By clicking Allow, you permit Blocks Cloud to use your information in accordance with
+            By clicking Allow, you permit Blocks IAM to use your information in accordance with
             its{" "}
             <Link
               to="https://selisegroup.com/software-development-terms/"
@@ -250,7 +250,7 @@ export const OIDCPermissionScreen = () => {
 //           )}
 //         </div>
 //         <CardDescription className="mt-3 text-lg text-foreground">
-//           You&apos;re about to connect your Blocks Account to Blocks Cloud
+//           You&apos;re about to connect your Blocks Account to Blocks IAM
 //         </CardDescription>
 //       </CardHeader>
 //       <CardContent className="mt-2 flex flex-1 flex-col justify-between">
@@ -264,7 +264,7 @@ export const OIDCPermissionScreen = () => {
 //             </ul>
 //           </div>
 //           <div className="my-4 text-left text-sm text-foreground">
-//             By clicking Allow, you permit Blocks Cloud to use your information in accordance with
+//             By clicking Allow, you permit Blocks IAM to use your information in accordance with
 //             its{" "}
 //             <Link
 //               to="https://selisegroup.com/software-development-terms/"

--- a/client/app/idp/authentication/pages/sso-activate/sso-activate.test.tsx
+++ b/client/app/idp/authentication/pages/sso-activate/sso-activate.test.tsx
@@ -42,7 +42,7 @@ beforeEach(() => {
 describe("SsoActivate", () => {
   it("renders the card with the terms checkbox and a disabled continue button", () => {
     renderComp();
-    expect(screen.getByText("Blocks Cloud")).toBeInTheDocument();
+    expect(screen.getByText("Blocks IAM")).toBeInTheDocument();
     expect(screen.getByText(/I agree to the/i)).toBeInTheDocument();
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();

--- a/client/app/idp/authentication/pages/sso-activate/sso-activate.tsx
+++ b/client/app/idp/authentication/pages/sso-activate/sso-activate.tsx
@@ -123,7 +123,7 @@ export const SsoActivate = ({ oauthParams }: SsoActivateProps) => {
   return (
     <Card className="w-full rounded border-solid border-background shadow-none md:border-[#95ADC4] lg:max-w-md">
       <CardHeader className="text-center">
-        <CardTitle className="text-3xl leading-9">Blocks Cloud</CardTitle>
+        <CardTitle className="text-3xl leading-9">Blocks IAM</CardTitle>
       </CardHeader>
       <CardContent>
         {config && (

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -216,6 +216,38 @@
             request identified by <c>user_code</c>. Returns the SPA's success-page redirect.
             </summary>
         </member>
+        <member name="T:Api.Controllers.DiscoveryController">
+            <summary>
+            OpenID Connect Discovery Endpoints
+            RFC 8414: OAuth 2.0 Authorization Server Metadata
+            OIDC Core 1.0: OpenID Connect Discovery 1.0
+            
+            These endpoints provide machine-readable metadata for client discovery
+            and automatic configuration.
+            </summary>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Api.Controllers.DiscoveryController.OpenIdConfiguration" -->
+        <member name="M:Api.Controllers.DiscoveryController.OAuthAuthorizationServer">
+            <summary>
+            OAuth Authorization Server Metadata Endpoint
+            RFC 8414 Section 3.2
+            
+            Provides metadata for OAuth Authorization Servers
+            Compatible with both OAuth and OIDC servers
+            
+            Standard response caching: 1 hour
+            </summary>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Api.Controllers.DiscoveryController.JwksJson" -->
+        <member name="M:Api.Controllers.DiscoveryController.ExecutePasswordLogin(Authentication.DomainService.OAuth.RequestModel.EmbeddedLoginRequest)">
+            <summary>
+            Temporary anonymous password-login surface. The absolute route <c>/auth-login</c>
+            deliberately escapes the discovery prefix and mirrors <c>POST /api/auth/login</c>.
+            DEPRECATED: this is a temporary compatibility route pending the device-code flow
+            replacement and is slated for removal once that flow ships. Do not build new clients
+            against it.
+            </summary>
+        </member>
         <member name="T:Api.Controllers.IdpController">
             <summary>
             IDP Controller
@@ -247,7 +279,7 @@
             Requires authentication and admin privileges
             </summary>
         </member>
-        <member name="M:Api.Controllers.OidcClientsController.GetAll">
+        <member name="M:Api.Controllers.OidcClientsController.GetOidcClients">
             <summary>
             Retrieve all OIDC clients for the tenant
             Returns list of registered OAuth 2.0 / OIDC client applications
@@ -271,7 +303,7 @@
             <response code="401">Authentication required</response>
             <response code="404">Client not found</response>
         </member>
-        <member name="M:Api.Controllers.OidcClientsController.Upsert(Authentication.DomainService.RequestModel.SaveOIDCClientRequest)">
+        <member name="M:Api.Controllers.OidcClientsController.UpsertOidcClient(Authentication.DomainService.RequestModel.SaveOIDCClientRequest)">
             <summary>
             Create or update OIDC client configuration (Upsert)
             Registers new OIDC client or updates existing configuration
@@ -284,7 +316,7 @@
             <response code="400">Invalid request payload or validation failure</response>
             <response code="401">Authentication required</response>
         </member>
-        <member name="M:Api.Controllers.OidcClientsController.Delete(System.String)">
+        <member name="M:Api.Controllers.OidcClientsController.DeleteOidcClient(System.String)">
             <summary>
             Delete OIDC client configuration
             Removes client application and revokes all issued tokens
@@ -303,10 +335,10 @@
             Generates a new client_secret for the existing client and returns it exactly once.
             The new secret is not stored anywhere else and subsequent GETs mask it as usual.
             </summary>
-            <param name="itemId">OIDC client identifier</param>
+            <param name="clientId">OIDC client identifier</param>
             <returns>The newly rotated client_secret (one-time disclosure)</returns>
             <response code="200">Secret rotated; response contains the new client_secret</response>
-            <response code="400">itemId is required or client not found</response>
+            <response code="400">clientId is required or client not found</response>
             <response code="401">Authentication required</response>
         </member>
         <member name="T:Api.Controllers.SecurityController">
@@ -348,29 +380,6 @@
             RFC 6749: OAuth 2.0 | RFC 3986: OpenID Connect | RFC 7519: JWT | RFC 5280: X.509
             </summary>
         </member>
-        <member name="T:Blocks.Api.Controllers.DiscoveryController">
-            <summary>
-            OpenID Connect Discovery Endpoints
-            RFC 8414: OAuth 2.0 Authorization Server Metadata
-            OIDC Core 1.0: OpenID Connect Discovery 1.0
-            
-            These endpoints provide machine-readable metadata for client discovery
-            and automatic configuration.
-            </summary>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:Blocks.Api.Controllers.DiscoveryController.OpenIdConfiguration" -->
-        <member name="M:Blocks.Api.Controllers.DiscoveryController.OAuthAuthorizationServer">
-            <summary>
-            OAuth Authorization Server Metadata Endpoint
-            RFC 8414 Section 3.2
-            
-            Provides metadata for OAuth Authorization Servers
-            Compatible with both OAuth and OIDC servers
-            
-            Standard response caching: 1 hour
-            </summary>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:Blocks.Api.Controllers.DiscoveryController.JwksJson" -->
         <!-- Badly formed XML comment ignored for member "T:Blocks.Api.Controllers.IdpSessionController" -->
         <member name="M:Blocks.Api.Controllers.IdpSessionController.GetSession">
             <summary>

--- a/server/Api/Controllers/AuthenticationController.cs
+++ b/server/Api/Controllers/AuthenticationController.cs
@@ -509,15 +509,14 @@ public class AuthenticationController : ControllerBase
 
     [HttpGet("config")]
     [ProtectedEndPoint("blocks-iam::auth::identity-config")]
-    public async Task<IActionResult> Get([FromQuery] GetAuthenticationConfigurationRequest request)
+    public async Task<IActionResult> GetAuthenticationConfiguration()
     {
-        
         return await _configurationService.GetAuthenticationConfigAsync();
     }
-    
+
     [HttpPost("config")]
     [ProtectedEndPoint("blocks-iam::auth::mutate-identity-config")]
-    public async Task<BaseResponse> Update([FromBody] UpdateAuthenticationConfigurationRequest configuration)
+    public async Task<BaseResponse> UpdateAuthenticationConfiguration([FromBody] UpdateAuthenticationConfigurationRequest configuration)
     {
         return await _configurationService.UpdateAuthenticationConfigAsync(configuration);
     }
@@ -557,7 +556,7 @@ public class AuthenticationController : ControllerBase
 
     [HttpGet("client-credentials")]
     [ProtectedEndPoint("blocks-iam::auth::client-credentials")]
-    public async Task<List<ClientCredential>> GetClientCredentials([FromQuery] GetAllClientCredentialsRequest request)
+    public async Task<List<ClientCredential>> GetClientCredentials()
     {
         return await _authenticationRepository.GetClientCredentialsAsync();
     }

--- a/server/Api/Controllers/DiscoveryController.cs
+++ b/server/Api/Controllers/DiscoveryController.cs
@@ -1,4 +1,5 @@
 using Authentication.DomainService.Authentication;
+using Authentication.DomainService.OAuth;
 using Authentication.DomainService.OAuth.RequestModel;
 using Blocks.Genesis;
 using Idp.DomainService.Oidc.Contracts;
@@ -7,7 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
 
-namespace Blocks.Api.Controllers
+namespace Api.Controllers
 {
     /// <summary>
     /// OpenID Connect Discovery Endpoints
@@ -141,9 +142,17 @@ namespace Blocks.Api.Controllers
             return JwksJson();
         }
 
+        /// <summary>
+        /// Temporary anonymous password-login surface. The absolute route <c>/auth-login</c>
+        /// deliberately escapes the discovery prefix and mirrors <c>POST /api/auth/login</c>.
+        /// DEPRECATED: this is a temporary compatibility route pending the device-code flow
+        /// replacement and is slated for removal once that flow ships. Do not build new clients
+        /// against it.
+        /// </summary>
         [HttpPost("/auth-login")]
+        [AllowAnonymous]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(JwksResponse), 200)]
+        [ProducesResponseType(typeof(OidcTokenEndpointResponse), 200)]
         public async Task<IActionResult> ExecutePasswordLogin([FromBody] EmbeddedLoginRequest request)
         {
             var section = _configuration.GetSection("FrontendRuntime");

--- a/server/Api/Controllers/IamController.cs
+++ b/server/Api/Controllers/IamController.cs
@@ -88,7 +88,7 @@ namespace Api.Controllers
 
         [HttpGet("permissions/by-severity")]
         [Authorize]
-        public async Task<List<PermissionGroupBySeverityResponse>> GetPermissionsGroupBySeverity([FromQuery] GetPermissionGroupBySeverityRequest request)
+        public async Task<List<PermissionGroupBySeverityResponse>> GetPermissionsGroupBySeverity()
         {
             return await _resourceQueryService.GetPermissionsGroupBySeverityAsync();
         }
@@ -116,10 +116,10 @@ namespace Api.Controllers
 
         [HttpPost("roles/assign-permissions")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-roles")]
-        public async Task<IActionResult> SetRoles([FromBody] SetRolesRequest command)
+        public async Task<IActionResult> AssignRolePermissions([FromBody] SetRolesRequest command)
         {
             var result = await _resourceMutationService.SetRolesAsync(command);
-            return result.Success ? Ok(result) : BadRequest(result);
+            return result.IsSuccess ? Ok(result) : BadRequest(result);
         }
 
         [HttpGet("roles/assignable")]
@@ -131,7 +131,7 @@ namespace Api.Controllers
 
         [HttpGet("resource-groups")]
         [ProtectedEndPoint("blocks-iam::iam::permissions")]
-        public async Task<List<GetResourceGroupResponse>> GetResourceGroups([FromQuery] GetResourceGroupRequest request)
+        public async Task<List<GetResourceGroupResponse>> GetResourceGroups()
         {
             return await _resourceQueryService.GetResourceGroupsAsync();
         }
@@ -149,7 +149,7 @@ namespace Api.Controllers
 
         [HttpPost("users/create")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-users")]
-        public async Task<IActionResult> Create([FromBody] CreateUserRequest command)
+        public async Task<IActionResult> CreateUser([FromBody] CreateUserRequest command)
         {
             var result = await _userManagementMutationService.CreateUserAsync(command);
             return result.IsSuccess ? Ok(result) : BadRequest(result);
@@ -157,7 +157,7 @@ namespace Api.Controllers
 
         [HttpPost("users/{id}")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-users")]
-        public async Task<IActionResult> Update([FromRoute] string id, [FromBody] UpdateUserRequest command)
+        public async Task<IActionResult> UpdateUser([FromRoute] string id, [FromBody] UpdateUserRequest command)
         {
             command.ItemId = id;
             var result = await _userManagementMutationService.UpdateUserAsync(command);
@@ -166,7 +166,7 @@ namespace Api.Controllers
 
         [HttpPost("users/deactivate")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-users")]
-        public async Task<IActionResult> Deactivate([FromBody] DeactivateUserRequest request)
+        public async Task<IActionResult> DeactivateUser([FromBody] DeactivateUserRequest request)
         {
             var result = await _userManagementMutationService.DeactivateUserAsync(request);
             return result.IsSuccess ? Ok(result) : BadRequest(result);
@@ -174,7 +174,7 @@ namespace Api.Controllers
 
         [HttpPost("users/activate")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-users")]
-        public async Task<IActionResult> Activate([FromBody] ActivateUserByAdminRequest request)
+        public async Task<IActionResult> ActivateUser([FromBody] ActivateUserByAdminRequest request)
         {
             var result = await _userManagementMutationService.ActivateUserAsync(request);
             return result.IsSuccess ? Ok(result) : BadRequest(result);

--- a/server/Api/Controllers/MfaController.cs
+++ b/server/Api/Controllers/MfaController.cs
@@ -16,6 +16,8 @@ using UserEntity = Iam.DomainService.Entities.User;
 namespace Api.Controllers;
 
 [ApiController]
+[Route("mfa")]
+// Deprecated: use "mfa". "api/mfa" kept as a temporary compatibility alias.
 [Route("api/mfa")]
 public class MfaController : ControllerBase
 {
@@ -47,7 +49,7 @@ public class MfaController : ControllerBase
 
     [HttpGet("config")]
     [ProtectedEndPoint("blocks-iam::iam::mfa-configs")]
-    public async Task<IActionResult> GetPolicy()
+    public async Task<IActionResult> GetMfaConfig()
     {
         var config = await _mfaConfigurationService.GetAsync() ?? new Configuration { UserMfaType = new List<UserMfaType>() };
         return Ok(new
@@ -65,7 +67,7 @@ public class MfaController : ControllerBase
 
     [HttpPost("config")]
     [ProtectedEndPoint("blocks-iam::iam::mutate-mfa-configs")]
-    public async Task<IActionResult> UpdatePolicy([FromBody] UpdateMfaPolicyRequest request, CancellationToken ct)
+    public async Task<IActionResult> UpdateMfaConfig([FromBody] UpdateMfaPolicyRequest request, CancellationToken ct)
     {
         var current = await _mfaConfigurationService.GetAsync() ?? new Configuration { UserMfaType = new List<UserMfaType>() };
         if (request.EnableMfa.HasValue) current.EnableMfa = request.EnableMfa.Value;
@@ -84,8 +86,10 @@ public class MfaController : ControllerBase
         return Ok(current);
     }
 
+    // Self-service: a user enrolls their own TOTP. Own-identity is enforced by operating
+    // solely on GetCurrentUserId(); no admin config scope is required.
     [HttpPost("totp/setup")]
-    [ProtectedEndPoint("blocks-iam::iam::mutate-mfa-configs")]
+    [Authorize]
     public async Task<IActionResult> SetupTotp()
     {
         var userId = GetCurrentUserId();
@@ -107,8 +111,9 @@ public class MfaController : ControllerBase
         });
     }
 
+    // Self-service: a user verifies their own TOTP enrollment. Own-identity enforced via GetCurrentUserId().
     [HttpPost("totp/verify-setup")]
-    [ProtectedEndPoint("blocks-iam::iam::mutate-mfa-configs")]
+    [Authorize]
     public async Task<IActionResult> VerifyTotpSetup([FromBody] VerifyTotpSetupRequest request)
     {
         var userId = GetCurrentUserId();
@@ -225,8 +230,9 @@ public class MfaController : ControllerBase
         return Ok(new { valid = true, userId = result.UserId });
     }
 
+    // Self-service: a user switches their own preferred MFA method. Own-identity enforced via GetCurrentUserId().
     [HttpPut("method")]
-    [ProtectedEndPoint("blocks-iam::iam::mutate-mfa-configs")]
+    [Authorize]
     public async Task<IActionResult> SetMfaMethod([FromBody] SetMfaMethodRequest request)
     {
         var userId = GetCurrentUserId();
@@ -327,8 +333,9 @@ public class MfaController : ControllerBase
         return Ok(new { enabled = false, method = UserMfaType.None.ToString() });
     }
 
+    // Self-service: a user disables their own MFA. Own-identity enforced via GetCurrentUserId().
     [HttpPost("disable")]
-    [ProtectedEndPoint("blocks-iam::iam::mutate-mfa-configs")]
+    [Authorize]
     public async Task<IActionResult> DisableMfa()
     {
         var userId = GetCurrentUserId();

--- a/server/Api/Controllers/OidcClientsController.cs
+++ b/server/Api/Controllers/OidcClientsController.cs
@@ -33,7 +33,7 @@ public class OidcClientsController : ControllerBase
     /// <response code="401">Authentication required</response>
     [HttpGet]
     [ProtectedEndPoint("blocks-iam::iam::oidc-clients")]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetOidcClients()
     {
         var response = await _authenticationDomainService.GetOidcClientsAsync();
 
@@ -93,7 +93,7 @@ public class OidcClientsController : ControllerBase
     /// <response code="401">Authentication required</response>
     [HttpPost]
     [ProtectedEndPoint("blocks-iam::iam::mutate-oidc-clients")]
-    public async Task<IActionResult> Upsert([FromBody] SaveOIDCClientRequest request)
+    public async Task<IActionResult> UpsertOidcClient([FromBody] SaveOIDCClientRequest request)
     {
         if (request == null)
         {
@@ -123,7 +123,7 @@ public class OidcClientsController : ControllerBase
     /// <response code="404">Client not found</response>
     [HttpDelete("{clientId}")]
     [ProtectedEndPoint("blocks-iam::iam::mutate-oidc-clients")]
-    public async Task<IActionResult> Delete([FromRoute] string clientId)
+    public async Task<IActionResult> DeleteOidcClient([FromRoute] string clientId)
     {
         if (string.IsNullOrWhiteSpace(clientId))
         {
@@ -145,21 +145,21 @@ public class OidcClientsController : ControllerBase
     /// Generates a new client_secret for the existing client and returns it exactly once.
     /// The new secret is not stored anywhere else and subsequent GETs mask it as usual.
     /// </summary>
-    /// <param name="itemId">OIDC client identifier</param>
+    /// <param name="clientId">OIDC client identifier</param>
     /// <returns>The newly rotated client_secret (one-time disclosure)</returns>
     /// <response code="200">Secret rotated; response contains the new client_secret</response>
-    /// <response code="400">itemId is required or client not found</response>
+    /// <response code="400">clientId is required or client not found</response>
     /// <response code="401">Authentication required</response>
-    [HttpPost("{itemId}/rotate-secret")]
+    [HttpPost("{clientId}/rotate-secret")]
     [ProtectedEndPoint("blocks-iam::iam::mutate-oidc-clients")]
-    public async Task<IActionResult> RotateSecret([FromRoute] string itemId, [FromBody] RotateOidcClientSecretRequest? request = null)
+    public async Task<IActionResult> RotateSecret([FromRoute] string clientId, [FromBody] RotateOidcClientSecretRequest? request = null)
     {
-        if (string.IsNullOrWhiteSpace(itemId))
+        if (string.IsNullOrWhiteSpace(clientId))
         {
-            return BadRequest(new { error = "id_required", message = "itemId is required." });
+            return BadRequest(new { error = "id_required", message = "clientId is required." });
         }
 
-        var response = await _authenticationDomainService.RotateOidcClientSecretAsync(itemId);
+        var response = await _authenticationDomainService.RotateOidcClientSecretAsync(clientId);
         if (!response.IsSuccess)
         {
             return BadRequest(response);

--- a/server/Api/Controllers/SecurityController.cs
+++ b/server/Api/Controllers/SecurityController.cs
@@ -98,6 +98,8 @@ namespace Api.Controllers
             return Ok(result);
         }
 
+        [HttpPost("refresh-tokens/{tokenId}/revoke")]
+        // Deprecated: use "refresh-tokens/{tokenId}/revoke". Old shape kept as a compatibility alias.
         [HttpPost("revoke/refresh-tokens/{tokenId}")]
         [ProtectedEndPoint("blocks-iam::iam::mutate-security-audit")]
         public async Task<IActionResult> RevokeRefreshToken(

--- a/server/Authentication.DomainService/Authentication/MfaPolicyService.cs
+++ b/server/Authentication.DomainService/Authentication/MfaPolicyService.cs
@@ -39,7 +39,8 @@ namespace Authentication.DomainService.Authentication
             }
 
             var allowedMethods = config.UserMfaType ?? new List<UserMfaType>();
-            var userRoles = user.Roles?.Keys?.ToList() ?? new List<string>();
+            var userRoles = user.Roles?.Values.SelectMany(r => r)
+                    .Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? new List<string>();
 
             if (config.MfaExemptRoles != null
                 && config.MfaExemptRoles.Count > 0

--- a/server/Directory.Build.props
+++ b/server/Directory.Build.props
@@ -3,5 +3,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- Surface the .editorconfig naming/code-style rules at build time. Rules are authored
+         at warning severity so CI stays green; TreatWarningsAsErrors is intentionally left off
+         and will be ratcheted per the plan in CONTRIBUTING.md. -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 </Project>

--- a/server/Iam.DomainService/Resources/RequestModel/SetRolesRequest.cs
+++ b/server/Iam.DomainService/Resources/RequestModel/SetRolesRequest.cs
@@ -11,6 +11,15 @@
     public class SetRolesResponse
     {
         public bool Success { get; set; }
+
+        // Aligns this envelope with the shared response contract's IsSuccess flag.
+        // Mirrors Success so existing payloads keep the Success field too.
+        public bool IsSuccess
+        {
+            get => Success;
+            set => Success = value;
+        }
+
         public Dictionary<string, string> Errors { get; set;} = new Dictionary<string, string>();
     }
 }

--- a/server/XUnitTest/Api/AuthenticationControllerTests.cs
+++ b/server/XUnitTest/Api/AuthenticationControllerTests.cs
@@ -668,7 +668,7 @@ namespace XUnitTest.ApiTests
             var sentinel = new OkObjectResult("config");
             _configService.Setup(c => c.GetAuthenticationConfigAsync()).ReturnsAsync(sentinel);
 
-            var result = await CreateController().Get(new GetAuthenticationConfigurationRequest());
+            var result = await CreateController().GetAuthenticationConfiguration();
 
             result.Should().BeSameAs(sentinel);
         }
@@ -680,7 +680,7 @@ namespace XUnitTest.ApiTests
             _configService.Setup(c => c.UpdateAuthenticationConfigAsync(It.IsAny<UpdateAuthenticationConfigurationRequest>()))
                 .ReturnsAsync(response);
 
-            var result = await CreateController().Update(new UpdateAuthenticationConfigurationRequest());
+            var result = await CreateController().UpdateAuthenticationConfiguration(new UpdateAuthenticationConfigurationRequest());
 
             result.Should().BeSameAs(response);
         }
@@ -744,7 +744,7 @@ namespace XUnitTest.ApiTests
             var list = new List<ClientCredential>();
             _authRepo.Setup(r => r.GetClientCredentialsAsync()).ReturnsAsync(list);
 
-            var result = await CreateController().GetClientCredentials(new GetAllClientCredentialsRequest());
+            var result = await CreateController().GetClientCredentials();
 
             result.Should().BeSameAs(list);
         }

--- a/server/XUnitTest/Api/DiscoveryControllerTests.cs
+++ b/server/XUnitTest/Api/DiscoveryControllerTests.cs
@@ -1,7 +1,7 @@
 using Authentication.DomainService.Authentication;
 using Authentication.DomainService.OAuth.RequestModel;
 using Authentication.DomainService.OAuth.ResponseModel;
-using Blocks.Api.Controllers;
+using Api.Controllers;
 using Blocks.Genesis;
 using FluentAssertions;
 using Idp.DomainService.Oidc.Contracts;

--- a/server/XUnitTest/Api/IamControllerTests.cs
+++ b/server/XUnitTest/Api/IamControllerTests.cs
@@ -138,7 +138,7 @@ namespace XUnitTest.ApiTests
             var response = new List<PermissionGroupBySeverityResponse>();
             _resourceQuery.Setup(s => s.GetPermissionsGroupBySeverityAsync()).ReturnsAsync(response);
 
-            var result = await CreateController().GetPermissionsGroupBySeverity(new GetPermissionGroupBySeverityRequest());
+            var result = await CreateController().GetPermissionsGroupBySeverity();
 
             result.Should().BeSameAs(response);
         }
@@ -206,7 +206,7 @@ namespace XUnitTest.ApiTests
             _resourceMutation.Setup(s => s.SetRolesAsync(It.IsAny<SetRolesRequest>()))
                 .ReturnsAsync(new SetRolesResponse { Success = true });
 
-            var result = await CreateController().SetRoles(new SetRolesRequest());
+            var result = await CreateController().AssignRolePermissions(new SetRolesRequest());
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -217,7 +217,7 @@ namespace XUnitTest.ApiTests
             _resourceMutation.Setup(s => s.SetRolesAsync(It.IsAny<SetRolesRequest>()))
                 .ReturnsAsync(new SetRolesResponse { Success = false });
 
-            var result = await CreateController().SetRoles(new SetRolesRequest());
+            var result = await CreateController().AssignRolePermissions(new SetRolesRequest());
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }
@@ -239,7 +239,7 @@ namespace XUnitTest.ApiTests
             var response = new List<GetResourceGroupResponse>();
             _resourceQuery.Setup(s => s.GetResourceGroupsAsync()).ReturnsAsync(response);
 
-            var result = await CreateController().GetResourceGroups(new GetResourceGroupRequest());
+            var result = await CreateController().GetResourceGroups();
 
             result.Should().BeSameAs(response);
         }
@@ -263,7 +263,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.CreateUserAsync(It.IsAny<CreateUserRequest>()))
                 .ReturnsAsync(new BaseMutationResponse { IsSuccess = true });
 
-            var result = await CreateController().Create(new CreateUserRequest());
+            var result = await CreateController().CreateUser(new CreateUserRequest());
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -274,7 +274,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.CreateUserAsync(It.IsAny<CreateUserRequest>()))
                 .ReturnsAsync(new BaseMutationResponse { IsSuccess = false });
 
-            var result = await CreateController().Create(new CreateUserRequest());
+            var result = await CreateController().CreateUser(new CreateUserRequest());
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }
@@ -285,7 +285,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.UpdateUserAsync(It.Is<UpdateUserRequest>(c => c.ItemId == "u-1")))
                 .ReturnsAsync(new BaseMutationResponse { IsSuccess = true });
 
-            var result = await CreateController().Update("u-1", new UpdateUserRequest());
+            var result = await CreateController().UpdateUser("u-1", new UpdateUserRequest());
 
             result.Should().BeOfType<OkObjectResult>();
             _userMutation.Verify(s => s.UpdateUserAsync(It.Is<UpdateUserRequest>(c => c.ItemId == "u-1")), Times.Once);
@@ -297,7 +297,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.DeactivateUserAsync(It.IsAny<DeactivateUserRequest>()))
                 .ReturnsAsync(new BaseResponse { IsSuccess = true });
 
-            var result = await CreateController().Deactivate(new DeactivateUserRequest());
+            var result = await CreateController().DeactivateUser(new DeactivateUserRequest());
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -308,7 +308,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.DeactivateUserAsync(It.IsAny<DeactivateUserRequest>()))
                 .ReturnsAsync(new BaseResponse { IsSuccess = false });
 
-            var result = await CreateController().Deactivate(new DeactivateUserRequest());
+            var result = await CreateController().DeactivateUser(new DeactivateUserRequest());
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }
@@ -319,7 +319,7 @@ namespace XUnitTest.ApiTests
             _userMutation.Setup(s => s.ActivateUserAsync(It.IsAny<ActivateUserByAdminRequest>()))
                 .ReturnsAsync(new BaseMutationResponse { IsSuccess = true });
 
-            var result = await CreateController().Activate(new ActivateUserByAdminRequest { UserId = "u-1", Reason = "test" });
+            var result = await CreateController().ActivateUser(new ActivateUserByAdminRequest { UserId = "u-1", Reason = "test" });
 
             result.Should().BeOfType<OkObjectResult>();
         }

--- a/server/XUnitTest/Api/MfaControllerTests.cs
+++ b/server/XUnitTest/Api/MfaControllerTests.cs
@@ -99,7 +99,7 @@ namespace XUnitTest.ApiTests
         {
             _mfaConfig.Setup(c => c.GetAsync()).ReturnsAsync((MfaConfiguration?)null);
 
-            var result = await CreateController().GetPolicy();
+            var result = await CreateController().GetMfaConfig();
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -116,7 +116,7 @@ namespace XUnitTest.ApiTests
                 BackupCodesCount = 10
             });
 
-            var result = await CreateController().GetPolicy();
+            var result = await CreateController().GetMfaConfig();
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -141,7 +141,7 @@ namespace XUnitTest.ApiTests
                 BackupCodesCount = 8
             };
 
-            var result = await CreateController().UpdatePolicy(request, CancellationToken.None);
+            var result = await CreateController().UpdateMfaConfig(request, CancellationToken.None);
 
             var ok = result.Should().BeOfType<OkObjectResult>().Subject;
             var saved = ok.Value.Should().BeOfType<MfaConfiguration>().Subject;

--- a/server/XUnitTest/Api/OidcClientsControllerTests.cs
+++ b/server/XUnitTest/Api/OidcClientsControllerTests.cs
@@ -29,7 +29,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.GetOidcClientsAsync())
                 .ReturnsAsync(new GetOIDCClientsResponse { IsSuccess = true });
 
-            var result = await CreateController().GetAll();
+            var result = await CreateController().GetOidcClients();
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -40,7 +40,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.GetOidcClientsAsync())
                 .ReturnsAsync(new GetOIDCClientsResponse { IsSuccess = false });
 
-            var result = await CreateController().GetAll();
+            var result = await CreateController().GetOidcClients();
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }
@@ -98,7 +98,7 @@ namespace XUnitTest.ApiTests
         [Fact]
         public async Task Upsert_NullRequest_ReturnsBadRequest()
         {
-            var result = await CreateController().Upsert(null);
+            var result = await CreateController().UpsertOidcClient(null);
 
             result.Should().BeOfType<BadRequestObjectResult>();
             _domainService.Verify(s => s.SaveOIDCClientAsync(It.IsAny<SaveOIDCClientRequest>()), Times.Never);
@@ -110,7 +110,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.SaveOIDCClientAsync(It.IsAny<SaveOIDCClientRequest>()))
                 .ReturnsAsync(new SaveOIDCClientResponse { IsSuccess = true, ItemId = "cid" });
 
-            var result = await CreateController().Upsert(new SaveOIDCClientRequest());
+            var result = await CreateController().UpsertOidcClient(new SaveOIDCClientRequest());
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -121,7 +121,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.SaveOIDCClientAsync(It.IsAny<SaveOIDCClientRequest>()))
                 .ReturnsAsync(new SaveOIDCClientResponse { IsSuccess = false });
 
-            var result = await CreateController().Upsert(new SaveOIDCClientRequest());
+            var result = await CreateController().UpsertOidcClient(new SaveOIDCClientRequest());
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }
@@ -131,7 +131,7 @@ namespace XUnitTest.ApiTests
         [Fact]
         public async Task Delete_MissingId_ReturnsBadRequest()
         {
-            var result = await CreateController().Delete("");
+            var result = await CreateController().DeleteOidcClient("");
 
             result.Should().BeOfType<BadRequestObjectResult>();
             _domainService.Verify(s => s.DeleteOidcClientAsync(It.IsAny<DeleteOIDCClientRequest>()), Times.Never);
@@ -143,7 +143,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.DeleteOidcClientAsync(It.Is<DeleteOIDCClientRequest>(r => r.ItemId == "cid")))
                 .ReturnsAsync(new Blocks.Genesis.BaseResponse { IsSuccess = true });
 
-            var result = await CreateController().Delete("cid");
+            var result = await CreateController().DeleteOidcClient("cid");
 
             result.Should().BeOfType<OkObjectResult>();
         }
@@ -154,7 +154,7 @@ namespace XUnitTest.ApiTests
             _domainService.Setup(s => s.DeleteOidcClientAsync(It.IsAny<DeleteOIDCClientRequest>()))
                 .ReturnsAsync(new Blocks.Genesis.BaseResponse { IsSuccess = false });
 
-            var result = await CreateController().Delete("cid");
+            var result = await CreateController().DeleteOidcClient("cid");
 
             result.Should().BeOfType<BadRequestObjectResult>();
         }

--- a/server/XUnitTest/Auth/MfaPolicyServiceTests.cs
+++ b/server/XUnitTest/Auth/MfaPolicyServiceTests.cs
@@ -59,11 +59,11 @@ namespace XUnitTest.Auth
                 MfaExemptRoles = ["admin"]
             });
 
-            // NOTE: MfaPolicyService matches against user.Roles.Keys, so the role name must be the
-            // dictionary key here (see "needs refactor" note - the service should read role values).
+            // Roles is Dictionary<organizationId, List<roleName>>: the exempt role name lives in the
+            // values, keyed by the org id.
             var user = new User
             {
-                Roles = new Dictionary<string, List<string>> { { "Admin", ["default"] } }
+                Roles = new Dictionary<string, List<string>> { { "org-1", ["Admin"] } }
             };
 
             var decision = await service.EvaluateAsync(user, clientId: null);
@@ -116,10 +116,11 @@ namespace XUnitTest.Auth
                 MfaRequiredRoles = ["manager"]
             });
 
-            // NOTE: MfaPolicyService matches against user.Roles.Keys (see "needs refactor" note).
+            // Roles is Dictionary<organizationId, List<roleName>>: the required role name lives in the
+            // values, keyed by the org id.
             var user = new User
             {
-                Roles = new Dictionary<string, List<string>> { { "Manager", ["default"] } }
+                Roles = new Dictionary<string, List<string>> { { "org-1", ["Manager"] } }
             };
 
             var decision = await service.EvaluateAsync(user, clientId: null);


### PR DESCRIPTION
This branch clears technical, product, and architectural debt. Backend and frontend suites are green (1546 / 1294).

Tickets are referenced (not closed) so they can be moved to review.

**Addressed:** #309 (MFA policy matches role names), #342 (/auth-login response type + AllowAnonymous), #343 (MFA self-service under [Authorize] with own-identity), #345 (route grammar, api/mfa kept as alias), #346 (IsSuccess/Success trap), #347 (action-name clarity, dead params removed), #348 (Blocks IAM branding on sign-in/consent), #349 (naming enforcement).

**Deferred (with reasons on the ticket):** #344 (scope-area normalization is IAM-grant-breaking, needs a coordinated seed).

**Pattern:** every public-surface rename keeps the old symbol/route/wire-field marked `[Obsolete]` / `@deprecated`, forwarding to the new name. No hard breaks.