### PR TITLE
ci: split sonarqube and sca into blocks-iam-server and blocks-iam-client

### DIFF
--- a/.github/variables/vars.env
+++ b/.github/variables/vars.env
@@ -1,8 +1,12 @@
 SONARQUBE_HOST=https://code.selise.biz
 AUTHOR=seliseblocks
 REPO_NAME=blocks-iam
-SOLUTION_NAME=Blocks.slnx
+SOLUTION_NAME=BlocksIAM.sln
 SONAR_KEY=SELISEdigitalplatforms_blocks-iam_62d59495-6ce4-4120-bdca-16038cc44414
+SONAR_KEY_SERVER=blocks-iam-server
+SONAR_KEY_CLIENT=blocks-iam-client
+SCA_PROJECT_SERVER=blocks-iam-server
+SCA_PROJECT_CLIENT=blocks-iam-client
 SERVICE_NAME=blocks-iam
 DOCKERFILE_CLIENT=Dockerfile
 DOCKERFILE_WORKER=Dockerfile.worker

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -23,9 +23,9 @@ env:
   # ========================================
   # Quality Checks
   # ========================================
-  RUN_TESTS: "false" # Usually disabled in dev for speed
-  RUN_SONARQUBE: "false" # Enable for testing the new dotnet-coverage integration
-  RUN_SCA_SCAN: "false" # Enable SCA Scan for dependency analysis
+  RUN_TESTS: "true" # Usually disabled in dev for speed
+  RUN_SONARQUBE: "true" # Enable for testing the new dotnet-coverage integration
+  RUN_SCA_SCAN: "true" # Enable SCA Scan for dependency analysis
 
   # ========================================
   # Tag Stategy for Build and GitOps

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -171,6 +171,7 @@ jobs:
       SONARQUBE_HOST: ${{ needs.initialization.outputs.sonarqube_host }}
       SONAR_PROJECT_KEY: ${{ needs.initialization.outputs.sonar_project_key_server }}
       SONAR_ORGANIZATION: ${{ needs.initialization.outputs.sonar_organization }}
+      SONAR_TARGET_BRANCH: "dev"
       WORKING_DIRECTORY: ${{ needs.initialization.outputs.working_directory }}
 
       # Optional: Specify tool versions (defaults shown)
@@ -238,6 +239,7 @@ jobs:
       SONARQUBE_HOST: ${{ needs.initialization.outputs.sonarqube_host }}
       SONAR_PROJECT_KEY: ${{ needs.initialization.outputs.sonar_project_key_client }}
       SONAR_ORGANIZATION: ${{ needs.initialization.outputs.sonar_organization }}
+      SONAR_TARGET_BRANCH: "dev"
       NODE_VERSION: "22"
       JAVA_VERSION: "17"
       HAS_SUBMODULES: ${{ needs.initialization.outputs.has_submodules == 'true' }}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -49,7 +49,8 @@ jobs:
       cluster_name: ${{ steps.config.outputs.cluster_name }}
       environment: ${{ steps.config.outputs.environment }}
       load_custom_vars: ${{ steps.config.outputs.load_custom_vars }}
-      project_name: ${{ steps.config.outputs.project_name }}
+      sca_project_server: ${{ steps.config.outputs.sca_project_server }}
+      sca_project_client: ${{ steps.config.outputs.sca_project_client }}
       project_version: ${{ steps.config.outputs.project_version }}
       run_tests: ${{ steps.config.outputs.run_tests }}
       run_sonarqube: ${{ steps.config.outputs.run_sonarqube }}
@@ -57,7 +58,8 @@ jobs:
       service_name: ${{ steps.config.outputs.service_name }} # e.g., your service name
       service_type: ${{ steps.config.outputs.service_type }} # e.g., webclient, webservice, winservice
       sonarqube_host: ${{ steps.config.outputs.sonarqube_host }} # e.g., https://code.selise.biz
-      sonar_project_key: ${{ steps.config.outputs.sonar_project_key }} # e.g., your SonarQube project key
+      sonar_project_key_server: ${{ steps.config.outputs.sonar_project_key_server }}
+      sonar_project_key_client: ${{ steps.config.outputs.sonar_project_key_client }}
       sonar_organization: ${{ steps.config.outputs.sonar_organization }} # e.g., your SonarQube org
       solution_name: ${{ steps.config.outputs.solution_name }} # e.g., YourSolution.sln for .NET
       tag_strategy: ${{ steps.config.outputs.tag_strategy }} # e.g., commit, semantic
@@ -102,16 +104,18 @@ jobs:
           echo "has_submodules=${HAS_SUBMODULES:-true}" >> $GITHUB_OUTPUT
           echo "dotnet_version=${DOTNET_VERSION:-10.0.x}" >> $GITHUB_OUTPUT
           # SCA Scan Configuration
-          echo "project_name=${PROJECT_NAME:-${{ github.repository }}}" >> $GITHUB_OUTPUT
+          echo "sca_project_server=${SCA_PROJECT_SERVER:-blocks-iam-server}" >> $GITHUB_OUTPUT
+          echo "sca_project_client=${SCA_PROJECT_CLIENT:-blocks-iam-client}" >> $GITHUB_OUTPUT
           echo "project_version=${PROJECT_VERSION:-${{ github.ref_name }}}" >> $GITHUB_OUTPUT
           echo "dependency_track_host=${DEPENDENCY_TRACK_HOST:-api-dt.seliseblocks.com}" >> $GITHUB_OUTPUT
           echo "dependency_track_frontend_url=${DEPENDENCY_TRACK_FRONTEND_URL:-sca.seliseblocks.com}" >> $GITHUB_OUTPUT
 
           # SonarQube specific configurations (map from vars.env names)
-          echo "sonar_project_key=${SONAR_KEY:-}" >> $GITHUB_OUTPUT
+          echo "sonar_project_key_server=${SONAR_KEY_SERVER:-blocks-iam-server}" >> $GITHUB_OUTPUT
+          echo "sonar_project_key_client=${SONAR_KEY_CLIENT:-blocks-iam-client}" >> $GITHUB_OUTPUT
           echo "sonar_organization=${AUTHOR:-}" >> $GITHUB_OUTPUT
           echo "solution_name=${SOLUTION_NAME:-YourSolution.sln}" >> $GITHUB_OUTPUT
-          echo "working_directory=${WORKING_DIRECTORY:-./src}" >> $GITHUB_OUTPUT
+          echo "working_directory=${WORKING_DIRECTORY:-./server}" >> $GITHUB_OUTPUT
 
           # Version based on environment (from versions.env)
           ENVIRONMENT="${{ env.ENVIRONMENT }}"
@@ -157,7 +161,7 @@ jobs:
   #         SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
 
   # Run SonarQube analysis on both push and pull_request
-  sonarqube:
+  sonarqube_server:
     # if: github.event_name == 'pull_request' && needs.initialization.outputs.run_sonarqube == 'true'
     if: needs.initialization.outputs.run_sonarqube == 'true'
     needs: [ initialization ]
@@ -165,7 +169,7 @@ jobs:
     with:
       SOLUTION_NAME: ${{ needs.initialization.outputs.solution_name }}
       SONARQUBE_HOST: ${{ needs.initialization.outputs.sonarqube_host }}
-      SONAR_PROJECT_KEY: ${{ needs.initialization.outputs.sonar_project_key }}
+      SONAR_PROJECT_KEY: ${{ needs.initialization.outputs.sonar_project_key_server }}
       SONAR_ORGANIZATION: ${{ needs.initialization.outputs.sonar_organization }}
       WORKING_DIRECTORY: ${{ needs.initialization.outputs.working_directory }}
 
@@ -187,13 +191,13 @@ jobs:
   # ==============================================
   # SCA Scan for .NET - Dependency Analysis
   # ==============================================
-  sca-scan-dotnet:
+  sca_server:
     if: needs.initialization.outputs.run_sca_scan == 'true'
     needs: [ initialization ]
     uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/sca-scan-dotnet.yml@main
     with:
       # Project Configuration
-      PROJECT_NAME: ${{ needs.initialization.outputs.project_name }}
+      PROJECT_NAME: ${{ needs.initialization.outputs.sca_project_server }}
       PROJECT_VERSION: ${{ needs.initialization.outputs.project_version }}
 
       # .NET Configuration
@@ -210,7 +214,7 @@ jobs:
       # SBOM_TOOL: "cdxgen" # Options: "cdxgen" (recommended), "cyclonedx-dotnet"
       USE_DOCKER: false # Value 'true' is Recommended for .NET (make false to use native installation)
       # DOCKER_DOTNET_VERSION: "dotnet9" # Match your .NET version: dotnet6, dotnet7, dotnet8, dotnet9
-      INCLUDE_FORMULATION: true
+      INCLUDE_FORMULATION: false
 
       # Dependency-Track Configuration
       DEPENDENCY_TRACK_HOST: ${{ needs.initialization.outputs.dependency_track_host }}
@@ -225,16 +229,54 @@ jobs:
       DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
       SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
 
+  sonarqube_client:
+    if: needs.initialization.outputs.run_sonarqube == 'true'
+    needs: [initialization]
+    uses: ./.github/workflows/sonarqube-client.yml
+    with:
+      WORKING_DIRECTORY: "client"
+      SONARQUBE_HOST: ${{ needs.initialization.outputs.sonarqube_host }}
+      SONAR_PROJECT_KEY: ${{ needs.initialization.outputs.sonar_project_key_client }}
+      SONAR_ORGANIZATION: ${{ needs.initialization.outputs.sonar_organization }}
+      NODE_VERSION: "22"
+      JAVA_VERSION: "17"
+      HAS_SUBMODULES: ${{ needs.initialization.outputs.has_submodules == 'true' }}
+      SKIP_QUALITY_GATE: false
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_GLOBAL }}
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+
+  sca_client:
+    if: needs.initialization.outputs.run_sca_scan == 'true'
+    needs: [initialization]
+    uses: ./.github/workflows/sca-client.yml
+    with:
+      WORKING_DIRECTORY: "client"
+      PROJECT_NAME: ${{ needs.initialization.outputs.sca_project_client }}
+      PROJECT_VERSION: ${{ needs.initialization.outputs.project_version }}
+      NODE_VERSION: "22"
+      SPEC_VERSION: "1.6"
+      INCLUDE_FORMULATION: false
+      DEPENDENCY_TRACK_HOST: ${{ needs.initialization.outputs.dependency_track_host }}
+      DEPENDENCY_TRACK_FRONTEND_URL: ${{ needs.initialization.outputs.dependency_track_frontend_url }}
+      AUTO_CREATE_PROJECT: true
+      ARTIFACT_RETENTION_DAYS: 2
+      HAS_SUBMODULES: ${{ needs.initialization.outputs.has_submodules == 'true' }}
+    secrets:
+      DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+
   # Build and push image
   build-client:
-    # needs: [initialization, sonarqube, sca-scan-dotnet]
-    needs: [ initialization, sonarqube ]
-    # if: ${{ github.event_name == 'push' && (success() || needs.sonarqube.result == 'skipped' ) && (success() || needs.sca-scan-dotnet.result == 'skipped' ) }}
+    # needs: [initialization, sonarqube_server, sonarqube_client, sca_server, sca_client]
+    needs: [ initialization, sonarqube_server, sonarqube_client ]
+    # if: ${{ github.event_name == 'push' && (success() || needs.sonarqube_server.result == 'skipped' ) && (success() || needs.sca_server.result == 'skipped' ) }}
     if: |
       github.event_name == 'push' &&
       always() &&
       needs.initialization.result == 'success' &&
-      (needs.sonarqube.result == 'success' || needs.sonarqube.result == 'skipped')
+      (needs.sonarqube_server.result == 'success' || needs.sonarqube_server.result == 'skipped') &&
+      (needs.sonarqube_client.result == 'success' || needs.sonarqube_client.result == 'skipped')
     uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/build-push.yml@main
     with:
       SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
@@ -278,14 +320,15 @@ jobs:
 
   # Build and push image
   build-worker:
-    # needs: [initialization, sonarqube, sca-scan-dotnet]
-    needs: [ initialization, sonarqube ]
-    # if: ${{ github.event_name == 'push' && (success() || needs.sonarqube.result == 'skipped' ) && (success() || needs.sca-scan-dotnet.result == 'skipped' ) }}
+    # needs: [initialization, sonarqube_server, sonarqube_client, sca_server, sca_client]
+    needs: [ initialization, sonarqube_server, sonarqube_client ]
+    # if: ${{ github.event_name == 'push' && (success() || needs.sonarqube_server.result == 'skipped' ) && (success() || needs.sca_server.result == 'skipped' ) }}
     if: |
       github.event_name == 'push' &&
       always() &&
       needs.initialization.result == 'success' &&
-      (needs.sonarqube.result == 'success' || needs.sonarqube.result == 'skipped')
+      (needs.sonarqube_server.result == 'success' || needs.sonarqube_server.result == 'skipped') &&
+      (needs.sonarqube_client.result == 'success' || needs.sonarqube_client.result == 'skipped')
     uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/build-push.yml@main
     with:
       SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}

--- a/.github/workflows/sca-client.yml
+++ b/.github/workflows/sca-client.yml
@@ -1,0 +1,194 @@
+name: Reusable - SCA Scan Client (Vite/TS)
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        description: "Directory containing the frontend package.json"
+        required: false
+        type: string
+        default: "client"
+
+      PROJECT_NAME:
+        description: "Dependency-Track project name"
+        required: true
+        type: string
+
+      PROJECT_VERSION:
+        description: "Dependency-Track project version"
+        required: false
+        type: string
+        default: ""
+
+      NODE_VERSION:
+        description: "Node.js version to use"
+        required: false
+        type: string
+        default: "22"
+
+      CDXGEN_VERSION:
+        description: "cdxgen version to install"
+        required: false
+        type: string
+        default: "latest"
+
+      SPEC_VERSION:
+        description: "CycloneDX spec version to emit"
+        required: false
+        type: string
+        default: "1.6"
+
+      INCLUDE_FORMULATION:
+        description: "Include build/CI provenance in the SBOM"
+        required: false
+        type: boolean
+        default: false
+
+      SBOM_FILENAME:
+        description: "SBOM filename to generate"
+        required: false
+        type: string
+        default: "bom.json"
+
+      DEPENDENCY_TRACK_HOST:
+        description: "Dependency-Track API hostname"
+        required: false
+        type: string
+        default: "api-dt.seliseblocks.com"
+
+      DEPENDENCY_TRACK_FRONTEND_URL:
+        description: "Dependency-Track frontend URL for dashboard links"
+        required: false
+        type: string
+        default: "sca.seliseblocks.com"
+
+      AUTO_CREATE_PROJECT:
+        description: "Auto-create the project in Dependency-Track if missing"
+        required: false
+        type: boolean
+        default: true
+
+      ARTIFACT_RETENTION_DAYS:
+        description: "Days to retain the SBOM artifact"
+        required: false
+        type: number
+        default: 2
+
+      HAS_SUBMODULES:
+        description: "Set to true if the repository uses Git submodules"
+        required: false
+        type: boolean
+        default: false
+
+    secrets:
+      DEPENDENCY_TRACK_API_KEY:
+        required: true
+        description: "Dependency-Track API key"
+      SELISE_GITHUB_PAT:
+        required: false
+        description: "GitHub PAT for private repositories and submodules"
+
+jobs:
+  sca-scan:
+    name: SCA Scan & SBOM Upload (Client)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: ${{ inputs.HAS_SUBMODULES && 'recursive' || 'false' }}
+          token: ${{ secrets.SELISE_GITHUB_PAT || github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.WORKING_DIRECTORY }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Generate SBOM with cdxgen
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm install -g @cyclonedx/cdxgen@${{ inputs.CDXGEN_VERSION }}
+
+          FORMULATION_FLAG=""
+          [ "${{ inputs.INCLUDE_FORMULATION }}" = "true" ] && FORMULATION_FLAG="--include-formulation"
+
+          cdxgen \
+            -t js \
+            -o ${{ inputs.SBOM_FILENAME }} \
+            --spec-version ${{ inputs.SPEC_VERSION }} \
+            $FORMULATION_FLAG \
+            .
+
+      - name: Validate SBOM
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          BOM="${{ inputs.SBOM_FILENAME }}"
+          [ ! -s "$BOM" ] && echo "❌ SBOM missing or empty" && exit 1
+          jq empty "$BOM" || { echo "❌ SBOM is not valid JSON"; exit 1; }
+
+          {
+            echo "### 📦 SBOM (Client)"
+            echo ""
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| Spec version | $(jq -r '.specVersion' "$BOM") |"
+            echo "| Components | $(jq -r '.components | length' "$BOM") |"
+            echo "| Dependencies | $(jq -r '.dependencies | length' "$BOM") |"
+            echo "| Size | $(du -h "$BOM" | cut -f1) |"
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-client
+          path: ${{ inputs.WORKING_DIRECTORY }}/${{ inputs.SBOM_FILENAME }}
+          retention-days: ${{ inputs.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Upload to Dependency-Track
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        env:
+          DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+        run: |
+          VERSION="${{ inputs.PROJECT_VERSION }}"
+          [ -z "$VERSION" ] && VERSION="${GITHUB_REF_NAME}"
+
+          BODY=$(mktemp)
+          CODE=$(curl -sS -o "$BODY" -w '%{http_code}' \
+            -X POST "https://${{ inputs.DEPENDENCY_TRACK_HOST }}/api/v1/bom" \
+            -H "X-Api-Key: $DT_API_KEY" \
+            -F "autoCreate=${{ inputs.AUTO_CREATE_PROJECT }}" \
+            -F "projectName=${{ inputs.PROJECT_NAME }}" \
+            -F "projectVersion=$VERSION" \
+            -F "bom=@${{ inputs.SBOM_FILENAME }}")
+
+          echo "HTTP $CODE"
+          cat "$BODY"
+
+          if [ "$CODE" -lt 200 ] || [ "$CODE" -ge 300 ]; then
+            {
+              echo "### ❌ Dependency-Track upload failed (HTTP $CODE)"
+              echo ""
+              echo '```'
+              head -c 2000 "$BODY"
+              echo '```'
+            } >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          {
+            echo "### ✅ Uploaded to Dependency-Track"
+            echo ""
+            echo "- Project: \`${{ inputs.PROJECT_NAME }}\` @ \`$VERSION\`"
+            echo "- Dashboard: https://${{ inputs.DEPENDENCY_TRACK_FRONTEND_URL }}/projects"
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sonarqube-client.yml
+++ b/.github/workflows/sonarqube-client.yml
@@ -67,6 +67,12 @@ on:
         type: boolean
         default: false
 
+      SONAR_TARGET_BRANCH:
+        description: "Long-lived branch this analysis is compared against"
+        required: false
+        type: string
+        default: "dev"
+
     secrets:
       SONAR_TOKEN:
         required: true
@@ -141,6 +147,7 @@ jobs:
           projectBaseDir: ${{ inputs.WORKING_DIRECTORY }}
           args: >
             -Dsonar.projectKey=${{ inputs.SONAR_PROJECT_KEY }}
+            ${{ github.event_name == 'pull_request' && format('-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2}', github.event.pull_request.number, github.head_ref, inputs.SONAR_TARGET_BRANCH) || format('-Dsonar.branch.name={0}', github.ref_name) }}
             ${{ inputs.SONAR_ORGANIZATION && format('-Dsonar.organization={0}', inputs.SONAR_ORGANIZATION) || '' }}
             -Dsonar.sources=${{ inputs.SONAR_SOURCES }}
             -Dsonar.tests=${{ inputs.SONAR_SOURCES }}

--- a/.github/workflows/sonarqube-client.yml
+++ b/.github/workflows/sonarqube-client.yml
@@ -1,0 +1,176 @@
+name: Reusable - SonarQube Client (Vite/TS) Analysis
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        description: "Directory containing the frontend package.json"
+        required: false
+        type: string
+        default: "client"
+
+      NODE_VERSION:
+        description: "Node.js version to use"
+        required: false
+        type: string
+        default: "22"
+
+      JAVA_VERSION:
+        description: "Java version for the SonarQube scanner"
+        required: false
+        type: string
+        default: "17"
+
+      TEST_COMMAND:
+        description: "npm script that runs tests and emits coverage/lcov.info"
+        required: false
+        type: string
+        default: "test:coverage"
+
+      SONARQUBE_HOST:
+        description: "SonarQube host URL (e.g. https://code.selise.biz)"
+        required: true
+        type: string
+
+      SONAR_PROJECT_KEY:
+        description: "SonarQube project key for the client project"
+        required: true
+        type: string
+
+      SONAR_ORGANIZATION:
+        description: "SonarQube organization key"
+        required: false
+        type: string
+        default: ""
+
+      SONAR_SOURCES:
+        description: "Comma-separated source directories, relative to WORKING_DIRECTORY"
+        required: false
+        type: string
+        default: "app"
+
+      COVERAGE_EXCLUSIONS:
+        description: "Paths excluded from coverage, relative to WORKING_DIRECTORY"
+        required: false
+        type: string
+        default: "app/**/*.test.*,app/**/*.spec.*,app/**/*.d.ts,app/**/main.tsx,app/**/test-utils/**,app/**/__mocks__/**,**/components/ui/**,**/__generated__/**,**/*.gen.*"
+
+      HAS_SUBMODULES:
+        description: "Set to true if the repository uses Git submodules"
+        required: false
+        type: boolean
+        default: false
+
+      SKIP_QUALITY_GATE:
+        description: "Skip the SonarQube quality gate check"
+        required: false
+        type: boolean
+        default: false
+
+    secrets:
+      SONAR_TOKEN:
+        required: true
+        description: "SonarQube token with analysis permissions"
+      SELISE_GITHUB_PAT:
+        required: false
+        description: "GitHub PAT for private repositories and submodules"
+
+jobs:
+  sonarqube-analysis:
+    name: SonarQube Code Analysis (Client)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: ${{ inputs.HAS_SUBMODULES && 'recursive' || 'false' }}
+          token: ${{ secrets.SELISE_GITHUB_PAT || github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.WORKING_DIRECTORY }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Run tests with coverage
+        id: tests
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        continue-on-error: true
+        run: npm run ${{ inputs.TEST_COMMAND }}
+
+      - name: Normalize coverage paths
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "coverage/lcov.info" ]; then
+            sed -i "s|$(pwd)/||g" coverage/lcov.info
+            echo "✅ Coverage report found and normalized" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ No coverage/lcov.info produced; analysis will report 0% coverage" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: "temurin"
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar-client-${{ hashFiles(format('{0}/package-lock.json', inputs.WORKING_DIRECTORY)) }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-client-
+
+      - name: SonarQube scan
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.SONARQUBE_HOST }}
+        with:
+          projectBaseDir: ${{ inputs.WORKING_DIRECTORY }}
+          args: >
+            -Dsonar.projectKey=${{ inputs.SONAR_PROJECT_KEY }}
+            ${{ inputs.SONAR_ORGANIZATION && format('-Dsonar.organization={0}', inputs.SONAR_ORGANIZATION) || '' }}
+            -Dsonar.sources=${{ inputs.SONAR_SOURCES }}
+            -Dsonar.tests=${{ inputs.SONAR_SOURCES }}
+            -Dsonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+            -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/__generated__/**,**/*.gen.*
+            -Dsonar.coverage.exclusions=${{ inputs.COVERAGE_EXCLUSIONS }}
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.typescript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.sourceEncoding=UTF-8
+
+      - name: SonarQube quality gate
+        if: ${{ !inputs.SKIP_QUALITY_GATE }}
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        timeout-minutes: 10
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.SONARQUBE_HOST }}
+        with:
+          scanMetadataReportFile: ${{ inputs.WORKING_DIRECTORY }}/.scannerwork/report-task.txt
+
+      - name: Analysis summary
+        if: always()
+        run: |
+          {
+            echo "### 🔍 SonarQube (Client)"
+            echo ""
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| Project key | \`${{ inputs.SONAR_PROJECT_KEY }}\` |"
+            echo "| Host | ${{ inputs.SONARQUBE_HOST }} |"
+            echo "| Sources | \`${{ inputs.WORKING_DIRECTORY }}/${{ inputs.SONAR_SOURCES }}\` |"
+            echo "| Tests | ${{ steps.tests.outcome }} |"
+          } >> $GITHUB_STEP_SUMMARY

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig(({ mode }) => {
       globals: true,
       setupFiles: ["./app/test-utils/vitest.setup.ts"],
       coverage: {
+      reporter: ["text", "lcov"],
         all: true,
         provider: "v8",
         reporter: ["text", "json", "json-summary", "html"],


### PR DESCRIPTION
Splits SonarQube and Dependency-Track into two projects per stack instead of one mixed project. **ci-dev.yml only** — stg and prod are untouched.

- **blocks-iam-server** — the .NET solution (Api + Worker), via the shared `sonarqube-dotnet.yml` and `sca-scan-dotnet.yml`.
- **blocks-iam-client** — the Vite/TS frontend in `client/`, via new local `sonarqube-client.yml` and `sca-client.yml`.

The client needs local workflows because the shared `sonarqube-js.yml` and `sca-scan-js.yml` assume the JS project sits at the repository root (root `npm ci`, hardcoded `coverage/lcov.info`, npm cache with no `cache-dependency-path`). If those gain a `WORKING_DIRECTORY` input, the local files can be deleted.

Also included:
- `working_directory` defaulted to `./src`, but the solution lives in `./server` — the .NET scans could not have worked. Fixed.
- vitest now emits `lcov` coverage; the default reporters don't, so Sonar would report 0%.
- `INCLUDE_FORMULATION: false` on the .NET SBOM — drops ~58% of the payload that contributes nothing to vulnerability matching.

`RUN_SONARQUBE` and `RUN_SCA_SCAN` are left at `false`, so this changes no runtime behaviour until enabled. The `blocks-iam-server` and `blocks-iam-client` projects must exist in SonarQube first.

Verified upstream on blocks-os: `sca_server` and `sca_client` both green after removing `--deep` from the shared dotnet SBOM step (cdxgen emitted ASP.NET route templates like `[controller]/[action]` into `services[].endpoints`, which fail Dependency-Track's RFC 3987 IRI check and caused every upload to 400).