### PR TITLE
Enhance user invitation flow to support organization selection in mul…

### DIFF
--- a/client/app/idp/iam/modules/user-management/invite-user/invite-user.test.tsx
+++ b/client/app/idp/iam/modules/user-management/invite-user/invite-user.test.tsx
@@ -94,7 +94,36 @@ describe("InviteUser", () => {
       userCreationType: 1,
       platform: "blocks_portal",
     });
+    expect(payload).not.toHaveProperty("organizationIds");
     expect(h.showSuccessToast).toHaveBeenCalledWith({ description: "Invitation is sent" });
+  });
+
+  it("creates a new user with organizationId when multi-org is enabled", async () => {
+    h.config = { data: { isMultiOrgEnabled: true }, isLoading: false };
+    h.orgs = {
+      data: { organizations: [{ itemId: "org-1", name: "Acme Org", isDisabled: false }] },
+      isLoading: false,
+    };
+    h.createUser.mockResolvedValue({ isSuccess: true });
+    const user = userEvent.setup();
+    renderInvite();
+    await user.click(screen.getByRole("button", { name: /invite user/i }));
+    await user.type(screen.getByPlaceholderText("name@company.com"), "new@user.com");
+
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(await screen.findByText("Acme Org"));
+
+    const submit = screen.getByRole("button", { name: /send invite/i });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    await waitFor(() => expect(h.createUser).toHaveBeenCalled());
+    const payload = h.createUser.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      email: "new@user.com",
+      organizationId: "org-1",
+    });
+    expect(payload).not.toHaveProperty("organizationIds");
   });
 
   const fillNewUser = async (user: ReturnType<typeof userEvent.setup>) => {

--- a/client/app/idp/iam/modules/user-management/invite-user/invite-user.tsx
+++ b/client/app/idp/iam/modules/user-management/invite-user/invite-user.tsx
@@ -137,7 +137,7 @@ export const InviteUser = () => {
   }, [open, isMultiOrgEnabled, orgsData, hasNonDefaultOrgs, form]);
 
   // When multi-org is disabled the org picker is hidden, and we don't send
-  // organizationIds in the payload — the user is implicitly scoped to the
+  // organizationId in the payload — the user is implicitly scoped to the
   // built-in "default" org on the server side.
 
   // If the form's currently selected org becomes hidden because the existing
@@ -203,15 +203,16 @@ const orgOptions = useMemo(() => {
         return;
       }
 
+      const { organizationIds: _organizationIds, ...restValues } = values;
       const res = await createUser({
-        ...values,
+        ...restValues,
         // Names are collected from the user on the activation form, not from the inviter.
         firstName: "",
         lastName: "",
         userPassType: 1,
         userCreationType: 1,
         platform: "blocks_portal",
-        ...(isMultiOrgEnabled ? { organizationIds: values.organizationIds } : {}),
+        ...(isMultiOrgEnabled ? { organizationId: selectedOrgId } : {}),
       });
       if (!res.isSuccess) {
         const msg =

--- a/client/app/idp/iam/modules/user-management/user-access/multi-org-access.test.tsx
+++ b/client/app/idp/iam/modules/user-management/user-access/multi-org-access.test.tsx
@@ -196,4 +196,27 @@ describe("MultiOrgAccess", () => {
     (h.removeProps!.onOpenChange as (open: boolean) => void)(false);
     await waitFor(() => expect(screen.queryByTestId("remove-membership")).toBeNull());
   });
+
+  it("disables revoke access for the default organization", () => {
+    h.userResult = {
+      data: {
+        data: {
+          itemId: "u1",
+          organizationIds: ["default"],
+          organizations: [{ organizationId: "default", roles: [], permissions: [] }],
+        },
+      },
+      isLoading: false,
+    };
+    h.orgsResult = {
+      data: { organizations: [{ itemId: "default", name: "Default", isDisabled: false }] },
+      isLoading: false,
+    };
+    h.rolesResult = { data: { data: [] } };
+    h.permsResult = { data: { data: [] } };
+    render(<MultiOrgAccess userId="u1" projectKey="p1" />);
+    expect(
+      screen.getByLabelText(/Revoke user's access from Default/i),
+    ).toBeDisabled();
+  });
 });

--- a/client/app/idp/iam/modules/user-management/user-access/multi-org-access.tsx
+++ b/client/app/idp/iam/modules/user-management/user-access/multi-org-access.tsx
@@ -34,6 +34,8 @@ type MultiOrgAccessProps = {
   projectKey: string;
 };
 
+const DEFAULT_ORGANIZATION_ID = "default";
+
 const encodeOrgSelection = (userId: string, orgId: string) => `${userId}:${orgId}`;
 const decodeOrgSelection = (value: string): { userId: string; orgId: string } | null => {
   const idx = value.indexOf(":");
@@ -251,6 +253,8 @@ export const MultiOrgAccess = ({ userId, projectKey }: MultiOrgAccessProps) => {
   };
 
   const selectedOrgRow = organizationRows.find((org) => org.organizationId === selectedOrgId);
+  const isDefaultOrganization =
+    selectedOrgRow?.organizationId === DEFAULT_ORGANIZATION_ID;
   const isLoading = isUserLoading || isOrgsLoading;
 
   return (
@@ -301,17 +305,24 @@ export const MultiOrgAccess = ({ userId, projectKey }: MultiOrgAccessProps) => {
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="mt-6 h-8 w-8 shrink-0 bg-destructive/10 text-destructive hover:bg-destructive hover:text-destructive-foreground"
-                      onClick={() => setRevokeTarget(selectedOrgRow)}
-                      aria-label={`Revoke user's access from ${selectedOrgRow.name}`}
-                    >
-                      <UserMinus className="h-4 w-4" />
-                    </Button>
+                    <span className="mt-6 inline-flex shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 bg-destructive/10 text-destructive hover:bg-destructive hover:text-destructive-foreground disabled:pointer-events-none disabled:opacity-50"
+                        onClick={() => setRevokeTarget(selectedOrgRow)}
+                        disabled={isDefaultOrganization}
+                        aria-label={`Revoke user's access from ${selectedOrgRow.name}`}
+                      >
+                        <UserMinus className="h-4 w-4" />
+                      </Button>
+                    </span>
                   </TooltipTrigger>
-                  <TooltipContent side="left">Revoke user access</TooltipContent>
+                  <TooltipContent side="left">
+                    {isDefaultOrganization
+                      ? "Default organization access cannot be revoked"
+                      : "Revoke user access"}
+                  </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             )}


### PR DESCRIPTION
…ti-org setup. Updated tests to verify user creation with organizationId and ensured organizationIds are not included in the payload. Added logic to disable revoke access for the default organization in the multi-org access component.