### PR TITLE
Fix the expired device outcome assertion and ignore local scan output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,8 @@ scripts/scan.sh
 
 # local scan and coverage output, never committed
 results/
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,6 @@ copilot-instructions.md
 !SECURITY.md
 !CODE_OF_CONDUCT.md
 scripts/scan.sh
+
+# local scan and coverage output, never committed
+results/

--- a/client/app/idp/authentication/pages/device/success.test.tsx
+++ b/client/app/idp/authentication/pages/device/success.test.tsx
@@ -59,7 +59,12 @@ describe("DeviceSuccessPage", () => {
 
   it("shows the expired copy", () => {
     renderAt("/device/t1/success?outcome=expired");
-    expect(screen.getByText("Session Expired")).toBeInTheDocument();
+    // The shell renders the outcome twice, as the heading and as the success
+    // title, the same way it does for the declined outcome above.
+    expect(screen.getAllByText("Session Expired").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("The device code expired before approval. You can close this window."),
+    ).toBeInTheDocument();
   });
 
   it("shows the neutral copy when the outcome is unknown", () => {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4751,9 +4751,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7648,9 +7648,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Brings `inception` up to `dev` for blocks-iam.

## Commits
- test(fe): fix the expired device outcome assertion
- chore: ignore local scan and coverage output
- fix(deps): bump js-yaml and brace-expansion to patched versions

## Verification
- Frontend unit tests: 1452 passed across 201 files (`vitest run`).
- gitleaks and trufflehog run locally before pushing. No verified secrets, and no findings introduced by these commits.
