### PR TITLE
[#403] Spec: Partial email search for Users list & Organization Members table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,11 @@ results/
 QWEN.md
 .clinerules
 .windsurfrules
+
+# --- local tooling scripts (Windows + bash) - do not commit ---
+scripts/scan.ps1
+scripts/deploy.sh
+scripts/deploy.ps1
+scripts/th_transform.py
+scripts/secrets.local.ps1
+deploy.log

--- a/server/Iam.DomainService/Users/Services/UserRepository.cs
+++ b/server/Iam.DomainService/Users/Services/UserRepository.cs
@@ -5,6 +5,7 @@ using Iam.DomainService.Services;
 using Iam.DomainService.Shared.Entities;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using System.Text.RegularExpressions;
 
 namespace Iam.DomainService.Users
 {
@@ -177,8 +178,11 @@ namespace Iam.DomainService.Users
 
             if (!string.IsNullOrWhiteSpace(filter.Name))
             {
+                // searchTerm stays unescaped: the Contains below is a literal
+                // comparison, so backslashes would have to be typed to match.
+                // Only the regex form of the term is escaped.
                 var searchTerm = filter.Name.Trim().ToLower();
-                var regex = new BsonRegularExpression(searchTerm, "i");
+                var regex = new BsonRegularExpression(Regex.Escape(searchTerm), "i");
 
                 var orFilters = new List<FilterDefinition<User>>
                 {
@@ -191,7 +195,14 @@ namespace Iam.DomainService.Users
             }
 
             if (!string.IsNullOrWhiteSpace(filter.Email))
-                filters.Add(builder.Eq(u => u.Email, NormalizeEmail(filter.Email)));
+            {
+                // Substring match, so a partial address finds a user the same way
+                // the Name filter above already does. Exact-match email lookups
+                // (GetUserByEmailAsync, login) go through a different path and are
+                // unaffected.
+                var emailTerm = NormalizeEmail(filter.Email);
+                filters.Add(builder.Regex(u => u.Email, new BsonRegularExpression(Regex.Escape(emailTerm), "i")));
+            }
 
             if (filter.Status?.Active == true)
                 filters.Add(builder.Eq(u => u.Active, true));

--- a/server/XUnitTest/IamTests/Users/UserRepositoryTests.cs
+++ b/server/XUnitTest/IamTests/Users/UserRepositoryTests.cs
@@ -6,6 +6,7 @@ using Iam.DomainService.Services;
 using Iam.DomainService.Shared.Entities;
 using Iam.DomainService.Users;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Moq;
 using XUnitTest.TestSupport;
@@ -261,6 +262,252 @@ namespace XUnitTest.IamTests.Users
         {
             Register(new[] { new ProjectPeople { ItemId = "pp1", UserId = "u1", TenantId = "tenant-9" } });
             (await Sut().GetProjectIdFromProjectPeopleAsync("u1")).Should().Be("tenant-9");
+        }
+
+        // ---------------------------------------------------------------------
+        // User list filtering (issue #403)
+        //
+        // These assert the query the repository actually hands to the driver.
+        // MongoMock returns every seeded item whatever the filter, so counting
+        // rows would prove nothing; instead the FilterDefinition is captured on
+        // its way into FindAsync, rendered, and inspected. Where the ticket
+        // describes matching behaviour, the captured pattern is then run over the
+        // section 7 fixture addresses. That proves the semantics of the pattern
+        // the application sends -- MongoDB evaluates it with PCRE2 rather than
+        // .NET, so the end-to-end walkthrough is still worth doing, but for
+        // literal text and Regex.Escape output the two engines agree.
+        // ---------------------------------------------------------------------
+
+        private const string JohnDoe = "john.doe@yopmail.com";
+        private const string JaneRoe = "jane.roe@yopmail.com";
+        private const string JDoeSpecial = "j.doe@special.test";
+        private const string JxDoe = "jXdoe@yopmail.com";
+
+        /// <summary>
+        /// Run <paramref name="query"/> through the repository and hand back the filter it built.
+        /// The capturing setup supplies its own cursor: Moq prefers the newest matching setup, so
+        /// without one it would shadow <see cref="MongoMock.SetupFind"/> and leave FindAsync null.
+        /// </summary>
+        private async Task<BsonDocument> CaptureUserFilterAsync(GetUsersFilter? filter)
+        {
+            var col = Register(new[] { new User { ItemId = "u1" } });
+            MongoMock.SetupCount(col, 1);
+
+            FilterDefinition<User>? captured = null;
+            col.Setup(c => c.FindAsync(
+                    It.IsAny<FilterDefinition<User>>(),
+                    It.IsAny<FindOptions<User, User>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<FilterDefinition<User>, FindOptions<User, User>, CancellationToken>(
+                    (f, _, _) => captured = f)
+                .ReturnsAsync(() => MongoMock.Cursor(new[] { new User { ItemId = "u1" } }));
+
+            await Sut().GetUsersAsync<User, BaseGetsRequest<GetUsersFilter>>(
+                new BaseGetsRequest<GetUsersFilter> { Filter = filter });
+
+            captured.Should().NotBeNull();
+            var registry = BsonSerializer.SerializerRegistry;
+            return captured!.Render(new RenderArgs<User>(registry.GetSerializer<User>(), registry));
+        }
+
+        /// <summary>
+        /// Find the clause for <paramref name="field"/> wherever the driver put it. Conjunctions may
+        /// be flattened or kept under $and, so both shapes are searched rather than assumed.
+        /// </summary>
+        private static BsonValue? Clause(BsonDocument rendered, string field)
+        {
+            if (rendered.TryGetValue(field, out var direct)) return direct;
+
+            foreach (var op in new[] { "$and", "$or", "$nor" })
+            {
+                if (!rendered.TryGetValue(op, out var branch)) continue;
+
+                foreach (var part in branch.AsBsonArray.OfType<BsonDocument>())
+                {
+                    var nested = Clause(part, field);
+                    if (nested is not null) return nested;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>The regex a clause carries, as a value rather than a $regex sub-document.</summary>
+        private static BsonRegularExpression Regex(BsonDocument rendered, string field)
+        {
+            var clause = Clause(rendered, field);
+            clause.Should().NotBeNull($"the filter should constrain {field}");
+            return clause!.AsBsonRegularExpression;
+        }
+
+        /// <summary>Every string value anywhere in the rendered filter, regexes excluded.</summary>
+        private static IEnumerable<string> AllStrings(BsonValue value) => value switch
+        {
+            BsonDocument doc => doc.Elements.SelectMany(e => AllStrings(e.Value)),
+            BsonArray array => array.SelectMany(AllStrings),
+            BsonString s => new[] { s.AsString },
+            _ => Array.Empty<string>(),
+        };
+
+        /// <summary>
+        /// Run the captured pattern with the options the query itself carries, not a hardcoded
+        /// IgnoreCase - otherwise these checks would still pass if the repository stopped asking
+        /// for a case-insensitive match.
+        /// </summary>
+        private static bool Matches(BsonRegularExpression regex, string candidate)
+        {
+            var options = System.Text.RegularExpressions.RegexOptions.None;
+            if (regex.Options.Contains('i')) options |= System.Text.RegularExpressions.RegexOptions.IgnoreCase;
+            if (regex.Options.Contains('m')) options |= System.Text.RegularExpressions.RegexOptions.Multiline;
+            if (regex.Options.Contains('s')) options |= System.Text.RegularExpressions.RegexOptions.Singleline;
+            if (regex.Options.Contains('x')) options |= System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace;
+
+            return new System.Text.RegularExpressions.Regex(regex.Pattern, options).IsMatch(candidate);
+        }
+
+        [Fact] // H1, C6
+        public async Task GetUsersAsync_EmailFilter_MatchesOnSubstringCaseInsensitively()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Email = "doe" });
+            var regex = Regex(rendered, "Email");
+
+            regex.Pattern.Should().Be("doe", "plain text must not gain escapes");
+            regex.Options.Should().Contain("i");
+            Matches(regex, JohnDoe).Should().BeTrue();
+            Matches(regex, JaneRoe).Should().BeFalse();
+        }
+
+        [Fact] // H1, example 2 -- "DOE" finds the same user as "doe"
+        public async Task GetUsersAsync_EmailFilter_IsCaseInsensitiveAndTrimmed()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Email = "  DOE  " });
+            var regex = Regex(rendered, "Email");
+
+            regex.Pattern.Should().Be("doe", "the term is trimmed and lowercased before it is escaped");
+            Matches(regex, JohnDoe).Should().BeTrue();
+            // Matches() honours the captured options, so this only passes while the query
+            // really does ask Mongo for a case-insensitive match.
+            Matches(regex, JohnDoe.ToUpperInvariant()).Should().BeTrue();
+        }
+
+        [Fact] // C1, example 3 -- the dot is literal, not "any character"
+        public async Task GetUsersAsync_EmailFilter_EscapesRegexSpecialCharacters()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Email = "j.doe" });
+            var regex = Regex(rendered, "Email");
+
+            regex.Pattern.Should().Be(@"j\.doe");
+            Matches(regex, JDoeSpecial).Should().BeTrue();
+            Matches(regex, JxDoe).Should().BeFalse("an unescaped dot would have matched the X");
+        }
+
+        [Fact] // C1
+        public async Task GetUsersAsync_EmailFilter_EscapesQuantifiers()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Email = "a+b" });
+            Regex(rendered, "Email").Pattern.Should().Be(@"a\+b");
+        }
+
+        // C2's "returns an empty list, not an error" is ultimately server behaviour; what is
+        // provable here is that the term still yields a well-formed clause and that the pattern
+        // matches none of the fixtures.
+        [Fact]
+        public async Task GetUsersAsync_EmailFilter_WithNoMatch_MatchesNoneOfTheFixtures()
+        {
+            var rendered = await CaptureUserFilterAsync(
+                new GetUsersFilter { Email = "nomatch@nowhere.test" });
+            var regex = Regex(rendered, "Email");
+
+            new[] { JohnDoe, JaneRoe, JDoeSpecial }
+                .Should().OnlyContain(email => !Matches(regex, email));
+        }
+
+        [Theory] // H6, C5
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task GetUsersAsync_BlankEmailFilter_AppliesNoEmailClause(string? email)
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Email = email });
+            Clause(rendered, "Email").Should().BeNull();
+        }
+
+        [Fact] // H5 -- the same escaping gap, closed for Name
+        public async Task GetUsersAsync_NameFilter_EscapesRegexSpecialCharacters()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Name = "O.Brien" });
+
+            foreach (var field in new[] { "FirstName", "LastName" })
+            {
+                var regex = Regex(rendered, field);
+                regex.Pattern.Should().Be(@"o\.brien");
+                Matches(regex, "o'brien").Should().BeFalse();
+                Matches(regex, "o.brien").Should().BeTrue();
+            }
+        }
+
+        [Fact] // C6 -- plain names are untouched by the escaping fix
+        public async Task GetUsersAsync_NameFilter_LeavesPlainTextUnescaped()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Name = "john" });
+            Regex(rendered, "FirstName").Pattern.Should().Be("john");
+        }
+
+        [Fact]
+        // The full-name clause compares a literal string, so the term it receives must stay
+        // unescaped even though the regex form of the same term is escaped. Escaping both is
+        // the obvious way to get this wrong, and it would silently break full-name search.
+        public async Task GetUsersAsync_NameFilter_KeepsTheFullNameComparisonUnescaped()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter { Name = "o.brien" });
+
+            // The full-name clause carries the term as a plain string; the two regex clauses
+            // carry the escaped form as a regex pattern. Asserting on the string values keeps
+            // this independent of how the driver serialises either one.
+            var literals = AllStrings(rendered).ToList();
+            literals.Should().Contain("o.brien");
+            literals.Should().NotContain(@"o\.brien", "the literal Contains term must not be escaped");
+            Regex(rendered, "FirstName").Pattern.Should().Be(@"o\.brien");
+        }
+
+        [Fact] // C4, H3 -- organization scope survives alongside the email filter
+        public async Task GetUsersAsync_EmailFilter_StillRestrictsToTheOrganization()
+        {
+            var rendered = await CaptureUserFilterAsync(
+                new GetUsersFilter { Email = "doe", OrganizationId = "org-a" });
+
+            Clause(rendered, "OrganizationIds").Should().NotBeNull();
+            AllStrings(rendered).Should().Contain("org-a");
+            Regex(rendered, "Email").Pattern.Should().Be("doe");
+        }
+
+        [Fact] // H4 -- every other filter still lands, unchanged
+        public async Task GetUsersAsync_EmailFilter_CombinesWithEveryOtherFilter()
+        {
+            var rendered = await CaptureUserFilterAsync(new GetUsersFilter
+            {
+                Email = "doe",
+                Name = "john",
+                Status = new Status { Active = true },
+                Mfa = new MFA { Enabled = true },
+                JoinedOn = DateTime.UtcNow.AddDays(-10),
+                LastLogin = DateTime.UtcNow.AddDays(-1),
+                UserIds = new List<string> { "u1" },
+                OrganizationId = "org-a"
+            });
+
+            Regex(rendered, "Email").Pattern.Should().Be("doe");
+            Regex(rendered, "FirstName").Pattern.Should().Be("john");
+
+            // Assert the values too, not just that a clause exists: presence alone would still
+            // pass if a neighbouring filter started emitting the wrong comparison.
+            Clause(rendered, "Active")!.AsBoolean.Should().BeTrue();
+            Clause(rendered, "MfaEnabled")!.AsBoolean.Should().BeTrue();
+            Clause(rendered, "CreatedDate")!["$gte"].Should().NotBeNull();
+            Clause(rendered, "LastLoggedInTime")!["$gte"].Should().NotBeNull();
+            // ItemId is the entity's BSON id, so the driver renders the $in against _id.
+            Clause(rendered, "_id")!["$in"].AsBsonArray.Select(v => v.AsString).Should().Equal("u1");
+            Clause(rendered, "OrganizationIds").Should().NotBeNull();
+            AllStrings(rendered).Should().Contain("org-a");
         }
     }
 }


### PR DESCRIPTION
## Ticket

#403 — https://github.com/SELISEdigitalplatforms/blocks-iam/issues/403

## What changed

Searching users by email now finds a match on **part** of an address, the way searching by name already did. Previously the Email filter was an equality test, so anything short of the complete address returned nothing — typing `doe` found no one, and only `john.doe@yopmail.com` in full would do. It is now a case-insensitive substring match.

The same change closes a second, quieter bug: neither the Email nor the Name filter escaped the search term before using it as a regex, so a `.` or a `+` in what someone typed was treated as a regex operator instead of the character they meant. Both are now escaped.

One backend method covers both screens — the Users list and the Organization Members table go through the same filter — so there is no frontend change.

Exact-match email lookups elsewhere (`GetUserByEmailAsync`, login) use a different code path and are untouched, as are the `OrganizationId`, `Status`, `Mfa`, `JoinedOn`, `LastLogin` and `UserIds` filters.

### Notes for the reviewer

- **The unescaped term is deliberate in one place.** The Name branch builds three clauses: two regexes over `FirstName`/`LastName`, and a literal `.Contains(...)` over the concatenated full name. Only the regexes are escaped — escaping the term the `Contains` receives would make it search for backslashes that nobody typed, silently breaking full-name search. There is a test pinning this exact distinction.
- **Performance is a conscious tradeoff, not an oversight.** An unanchored substring regex cannot use a normal index, and `GetUsersAsync` evaluates the filter for both `CountDocumentsAsync` and `FindAsync`. The ticket accepts this explicitly (assumptions A2 and C3): it is the same tradeoff the `Name` filter has been shipping with, and no index is added here because a substring regex could not use one anyway. Worth confirming against production-scale data before this goes past `dev`.
- **One commit in this PR is not mine.** `d1f1c54b chore: ignore local scan/deploy tooling` was already on `inception` and not yet in `dev` when this work started, so comparing the two branches picks it up. It is left exactly as it is. This ticket's change is the single commit `8ca55bfb`, touching 2 files.

## Testing

- **Unit:** 13 new test cases (10 `[Fact]`, one `[Theory]` with 3 rows), added to the existing `UserRepositoryTests` suite rather than a parallel file. That class now runs 36 tests, all passing.
- **Full suite:** `dotnet test server/XUnitTest/XUnitTest.csproj` → **2052 tests, 2052 passed, 0 failed**, count read from the TRX result file rather than inferred from the exit code.
- **Coverage:** the changed region of `BuildUserFilter` is at **100%** line coverage (15/15); `UserRepository.cs` overall is at 91.49%. Note that the repo's `server/XUnitTest/coverage.runsettings` **excludes `**/*Repository.cs`**, so this file is invisible to the standard coverage run — these numbers come from a one-off local override that keeps every other exclusion. The repo's settings were deliberately not modified.
- **How the tests prove behaviour.** `MongoMock` returns every seeded item regardless of the filter, so asserting row counts would prove nothing. Instead each test captures the real `FilterDefinition<User>` on its way into `FindAsync`, renders it, and inspects the query the repository actually built — then runs the captured pattern over the ticket's §7 fixture addresses to check which ones it matches. **Caveat worth knowing:** that second step is evaluated by .NET's regex engine, while MongoDB uses PCRE2. For literal text and `Regex.Escape` output the two agree, but this is not a substitute for running the query against a real server.
- **e2e:** not executed. Section 7 needs a running instance seeded with three users across two organizations; this change did not provision or mutate any environment. Every §7 step has an equivalent unit test, but **the walkthrough still needs a human pass before merge** — particularly step 4, which is the one that would catch a PCRE2/.NET divergence.

## Review

codex (gpt-5.6-sol, high effort): 2 cycles on the plan, 2 cycles on the final diff.
Self-review: 2 cycles.

Plan review cycle 1 raised 1 critical / 3 major / 3 minor and materially changed the approach: it caught that rendering a filter proves serialization rather than matching, that `coverage.runsettings` hides this file from coverage, and that an `InternalsVisibleTo` I had planned was unnecessary — which removed a production visibility change and cut the diff from three files to two. Cycle 2 raised one major (a Moq detail: the capturing setup must supply its own `ReturnsAsync` or it shadows `MongoMock.SetupFind`), addressed before implementing.

Code review cycle 1 returned 0 critical / 0 major / 3 minor; two were test-quality points worth fixing — the fixture matcher now derives its options from the captured query instead of hardcoding case-insensitivity, and the combined-filters test asserts operators and values rather than mere clause presence. Cycle 2 came back clean.

No unresolved critical findings.
