### PR TITLE
[#451] SPEC - Global Password Blacklist in BlocksRootDb

### DIFF
--- a/server/Authentication.DomainService/Oidc/Services/BlacklistIndexWorker.cs
+++ b/server/Authentication.DomainService/Oidc/Services/BlacklistIndexWorker.cs
@@ -1,0 +1,51 @@
+using Iam.DomainService.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Authentication.DomainService.Oidc.Services
+{
+    /// <summary>
+    /// Ensures the password blacklist's (Key, Value) index exists on the root database, once at
+    /// startup.
+    /// </summary>
+    /// <remarks>
+    /// Registered through <c>RegisterAllServices()</c>, which both the Api and the Worker call, so
+    /// this runs in both processes. That is harmless: creating an index that already exists is a
+    /// no-op in MongoDB, so two simultaneous starts cannot produce a duplicate.
+    ///
+    /// Index creation is a performance concern, never a correctness one - the blacklist lookup is
+    /// right with or without it - so a failure here must not stop the service from starting.
+    /// </remarks>
+    public sealed class BlacklistIndexWorker : BackgroundService
+    {
+        private readonly IIdentityAccessManagementRepository _repository;
+        private readonly ILogger<BlacklistIndexWorker> _logger;
+
+        public BlacklistIndexWorker(
+            IIdentityAccessManagementRepository repository,
+            ILogger<BlacklistIndexWorker> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+            EnsureIndexesOnceAsync(stoppingToken);
+
+        /// <summary>
+        /// The whole of this worker's behaviour, exposed directly because the host decides when
+        /// <see cref="ExecuteAsync"/> runs and a unit test cannot drive that reliably.
+        /// </summary>
+        public async Task EnsureIndexesOnceAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                await _repository.EnsureIndexesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "BlacklistIndexWorker: EnsureIndexesAsync failed during startup.");
+            }
+        }
+    }
+}

--- a/server/Authentication.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Authentication.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -116,6 +116,7 @@ namespace Authentication.DomainService.Utilities
             serviceCollection.AddSingleton<DeviceVerificationService>();
             serviceCollection.AddSingleton<DeviceCodeExchangeService>();
             serviceCollection.AddHostedService<DeviceCleanupWorker>();
+            serviceCollection.AddHostedService<BlacklistIndexWorker>();
             serviceCollection.AddSingleton<IdpTokenExchangeClient>();
             serviceCollection.AddSingleton<IAuthSessionFacade, AuthSessionFacade>();
             serviceCollection.AddSingleton<IAuthStrategy, AuthStrategy>();

--- a/server/Iam.DomainService/Accounts/Validators/PasswordValidator.cs
+++ b/server/Iam.DomainService/Accounts/Validators/PasswordValidator.cs
@@ -38,8 +38,9 @@ namespace Iam.DomainService.Accounts
 
         protected async Task<bool> CheckBlackListPassword(string password, CancellationToken cancellationToken)
         {
-            var tenantId = BlocksContext.GetContext()?.TenantId;
-            var isExist = await _identityAccessManagementRepository.CheckPasswordBlackListedAsync(password, tenantId);
+            // No tenant is read: the blacklist is global, so the check must run even on paths that
+            // have no tenant context rather than treating the password as safe.
+            var isExist = await _identityAccessManagementRepository.CheckPasswordBlackListedAsync(password);
             return !isExist;
         }
     }

--- a/server/Iam.DomainService/Shared/Services/IIdentityAccessManagementRepository.cs
+++ b/server/Iam.DomainService/Shared/Services/IIdentityAccessManagementRepository.cs
@@ -15,7 +15,10 @@ namespace Iam.DomainService.Services
         Task<User> GetUserByIdAsync(string itemId);
         Task<T> GetUserByIdAsync<T>(string itemId);
         Task<IamConfiguration> GetIamConfigurationAsync();
-        Task<bool> CheckPasswordBlackListedAsync(string password, string tenantId);
+        Task<bool> CheckPasswordBlackListedAsync(string password);
+
+        /// <summary>Idempotently ensures the (Key, Value) index on the root blacklist collection.</summary>
+        Task EnsureIndexesAsync(CancellationToken ct = default);
         Task<bool> InsertUserKeyMapAsync(UserKeyMap userKeyMap);
         Task<bool> UpdateUserKeyMapActivationAsync(string userId);
         Task<List<UserKeyMap>> GetActiveUserKeyMapAsync(string userId);
@@ -25,3 +28,4 @@ namespace Iam.DomainService.Services
         Task<TenantConfiguration> GetTenantConfigurationAsync();
     }
 }
+

--- a/server/Iam.DomainService/Shared/Services/IdentityAccessManagementRepository.cs
+++ b/server/Iam.DomainService/Shared/Services/IdentityAccessManagementRepository.cs
@@ -2,6 +2,7 @@
 using Iam.DomainService.Dtos;
 using Iam.DomainService.Entities;
 using Iam.DomainService.Shared.Entities;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace Iam.DomainService.Services
@@ -9,10 +10,32 @@ namespace Iam.DomainService.Services
     public class IdentityAccessManagementRepository : BaseRepository, IIdentityAccessManagementRepository
     {
         private const string IdentityConfigurationCollectionName = "IdentityConfigurations";
+        private const string BlackListCollectionName = "BlackListInformations";
+        private const string BlackListIndexName = "ix_key_value";
+        private const string BlackListPasswordKey = "password";
 
-        public IdentityAccessManagementRepository(IDbContextProvider dbContextProvider) : base(dbContextProvider)
+        private readonly IBlocksSecret _blocksSecret;
+        private readonly ILogger<IdentityAccessManagementRepository> _logger;
+
+        public IdentityAccessManagementRepository(
+            IDbContextProvider dbContextProvider,
+            IBlocksSecret blocksSecret,
+            ILogger<IdentityAccessManagementRepository> logger) : base(dbContextProvider)
         {
+            _blocksSecret = blocksSecret;
+            _logger = logger;
         }
+
+        /// <summary>
+        /// The password blacklist is global on purpose: it lives in the root database so one entry
+        /// blocks that password for every tenant. Resolving it per tenant, as this used to, meant a
+        /// blacklisted password was enforced for exactly one tenant and silently ignored everywhere
+        /// else.
+        /// </summary>
+        private IMongoCollection<BlackListInformation> GetBlackListCollection() =>
+            _dbContextProvider
+                .GetDatabase(_blocksSecret.DatabaseConnectionString, _blocksSecret.RootDatabaseName, false)
+                .GetCollection<BlackListInformation>(BlackListCollectionName);
 
         public async Task<IamConfiguration> GetIamConfigurationAsync()
         {
@@ -53,17 +76,34 @@ namespace Iam.DomainService.Services
             return await cursor.FirstOrDefaultAsync();
         }
 
-        public async Task<bool> CheckPasswordBlackListedAsync(string password, string tenantId)
+        public async Task<bool> CheckPasswordBlackListedAsync(string password)
         {
-            if (string.IsNullOrWhiteSpace(tenantId))
-            {
-                return false;
-            }
-
-            var collection = GetCollection<BlackListInformation>(tenantId);
-            var result = await collection.CountDocumentsAsync(x => x.Key == "password" && x.Value == password);
+            // Deliberately unguarded: no tenant check, and no try/catch. If the root database
+            // cannot be reached the exception must reach the caller and fail the request, because
+            // reporting "not blacklisted" on an outage is precisely the failure this replaces.
+            var collection = GetBlackListCollection();
+            var result = await collection.CountDocumentsAsync(x => x.Key == BlackListPasswordKey && x.Value == password);
 
             return result > 0;
+        }
+
+        public async Task EnsureIndexesAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                var keys = Builders<BlackListInformation>.IndexKeys;
+                await GetBlackListCollection().Indexes.CreateOneAsync(
+                    new CreateIndexModel<BlackListInformation>(
+                        keys.Ascending(x => x.Key).Ascending(x => x.Value),
+                        new CreateIndexOptions<BlackListInformation> { Name = BlackListIndexName }),
+                    cancellationToken: ct);
+            }
+            catch (Exception ex)
+            {
+                // Startup must not hinge on index creation: the lookup is correct without the
+                // index, only slower, and creation is idempotent so a later start retries it.
+                _logger.LogWarning(ex, "IdentityAccessManagementRepository.EnsureIndexesAsync failed; index creation is idempotent and will be retried.");
+            }
         }
 
         public async Task<bool> InsertUserKeyMapAsync(UserKeyMap userKeyMap)

--- a/server/Iam.DomainService/Users/Services/IUserRepository.cs
+++ b/server/Iam.DomainService/Users/Services/IUserRepository.cs
@@ -7,7 +7,7 @@ namespace Iam.DomainService.Users
     public interface IUserRepository
     {
         Task<User> GetUserByUserNameOrgIdAsync(string userName, string organizatoinId = "");
-        Task<bool> CheckPasswordBlackListedAsync(string password, string tenantId);
+        Task<bool> CheckPasswordBlackListedAsync(string password);
         Task<User> GetUserByEmailAsync(string email);
         Task<bool> CreateUserAsync(User user);
         Task<User> GetUserByIdAsync(string itemId);
@@ -24,3 +24,4 @@ namespace Iam.DomainService.Users
         Task<string> GetProjectIdFromProjectPeopleAsync(string userId);
     }
 }
+

--- a/server/Iam.DomainService/Users/Services/UserRepository.cs
+++ b/server/Iam.DomainService/Users/Services/UserRepository.cs
@@ -18,9 +18,9 @@ namespace Iam.DomainService.Users
             _identityAccessManagementRepository = identityAccessManagementRepository;
         }
 
-        public async Task<bool> CheckPasswordBlackListedAsync(string password, string tenantId)
+        public async Task<bool> CheckPasswordBlackListedAsync(string password)
         {
-            return await _identityAccessManagementRepository.CheckPasswordBlackListedAsync(password, tenantId);
+            return await _identityAccessManagementRepository.CheckPasswordBlackListedAsync(password);
         }
 
         public async Task<bool> CreateUserAsync(User user)

--- a/server/Iam.DomainService/Users/Validators/CreateUserValidator.cs
+++ b/server/Iam.DomainService/Users/Validators/CreateUserValidator.cs
@@ -110,8 +110,9 @@ namespace Iam.DomainService.Users
 
         private async Task<bool> CheckBlackListPassword(string password, CancellationToken cancellationToken)
         {
-            var tenantId = BlocksContext.GetContext()?.TenantId;
-            var isExist = await _userRepository.CheckPasswordBlackListedAsync(password, tenantId);
+            // No tenant is read: the blacklist is global, so the check must run even on paths that
+            // have no tenant context rather than treating the password as safe.
+            var isExist = await _userRepository.CheckPasswordBlackListedAsync(password);
             return !isExist;
         }
 

--- a/server/XUnitTest/Auth/Shared/ApplicationServiceCollectionExtensionsTests.cs
+++ b/server/XUnitTest/Auth/Shared/ApplicationServiceCollectionExtensionsTests.cs
@@ -58,7 +58,21 @@ namespace XUnitTest.Auth.Shared
         {
             var services = Registered();
 
-            services.Should().Contain(d => d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService));
+            // Assert the specific worker, not merely that some IHostedService exists: with two
+            // hosted services registered, the weaker check passes even if one is missing entirely.
+            services.Should().Contain(d =>
+                d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService) &&
+                d.ImplementationType == typeof(Authentication.DomainService.Oidc.Services.DeviceCleanupWorker));
+        }
+
+        [Fact]
+        public void RegisterAllServices_RegistersBlacklistIndexHostedService()
+        {
+            var services = Registered();
+
+            services.Should().Contain(d =>
+                d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService) &&
+                d.ImplementationType == typeof(Authentication.DomainService.Oidc.Services.BlacklistIndexWorker));
         }
 
         [Fact]

--- a/server/XUnitTest/Auth/Shared/BlacklistIndexWorkerTests.cs
+++ b/server/XUnitTest/Auth/Shared/BlacklistIndexWorkerTests.cs
@@ -1,0 +1,74 @@
+﻿using Authentication.DomainService.Oidc.Services;
+using FluentAssertions;
+using Iam.DomainService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace XUnitTest.Auth.Shared
+{
+    /// <summary>
+    /// Unit tests for <see cref="BlacklistIndexWorker"/>, the startup hook that ensures the password
+    /// blacklist's index exists.
+    /// </summary>
+    public sealed class BlacklistIndexWorkerTests
+    {
+        private readonly Mock<IIdentityAccessManagementRepository> _repository = new();
+
+        private BlacklistIndexWorker Sut() =>
+            new(_repository.Object, NullLogger<BlacklistIndexWorker>.Instance);
+
+        /// <summary>
+        /// Drives the worker's behaviour directly. StartAsync cannot be used here: the host, not
+        /// BackgroundService.StartAsync, decides when ExecuteAsync runs on this framework version,
+        /// so asserting through it would test the host rather than this worker.
+        /// </summary>
+        private static Task RunToCompletionAsync(BlacklistIndexWorker worker, CancellationToken ct) =>
+            worker.EnsureIndexesOnceAsync(ct);
+
+        [Fact]
+        public async Task Startup_EnsuresIndexesOnce()
+        {
+            var calls = 0;
+            _repository
+                .Setup(r => r.EnsureIndexesAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => calls++)
+                .Returns(Task.CompletedTask);
+
+            await RunToCompletionAsync(Sut(), CancellationToken.None);
+
+            calls.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Startup_PassesTheStoppingTokenThrough()
+        {
+            using var cts = new CancellationTokenSource();
+            CancellationToken observed = default;
+            _repository
+                .Setup(r => r.EnsureIndexesAsync(It.IsAny<CancellationToken>()))
+                .Callback<CancellationToken>(t => observed = t)
+                .Returns(Task.CompletedTask);
+
+            await RunToCompletionAsync(Sut(), cts.Token);
+
+            // The worker must hand its own stopping token down, so a shutdown mid-creation is
+            // cancellable rather than detached.
+            observed.Should().NotBe(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task Startup_DoesNotBlockStartupWhenIndexCreationFails()
+        {
+            _repository
+                .Setup(r => r.EnsureIndexesAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("no permission to create indexes"));
+
+            // The blacklist lookup is correct without the index, so a service that cannot create it
+            // must still come up rather than crash-looping.
+            var run = async () => await RunToCompletionAsync(Sut(), CancellationToken.None);
+
+            await run.Should().NotThrowAsync();
+        }
+    }
+}
+

--- a/server/XUnitTest/IamTests/Accounts/Validators/BaseAccountValidatorTests.cs
+++ b/server/XUnitTest/IamTests/Accounts/Validators/BaseAccountValidatorTests.cs
@@ -1,4 +1,4 @@
-using Blocks.CaptchaDriver;
+﻿using Blocks.CaptchaDriver;
 using Blocks.Genesis;
 using FluentAssertions;
 using Iam.DomainService.Accounts;
@@ -32,7 +32,7 @@ namespace XUnitTest.IamTests.Accounts.Validators
             _cache.Setup(c => c.KeyExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
             _configRepo.Setup(c => c.GetConfigurationAsync())
                 .ReturnsAsync(new IamConfiguration { PasswordStrengthCheckerRegex = string.Empty });
-            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>()))
                 .ReturnsAsync(false);
             _dbContext.Setup(d => d.GetCollection<Secret>("Secrets")).Returns(EmptySecrets());
         }
@@ -106,13 +106,27 @@ namespace XUnitTest.IamTests.Accounts.Validators
         [Fact]
         public async Task Password_Blacklisted_Fails()
         {
-            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>()))
                 .ReturnsAsync(true);
 
             var result = await Create().ValidateAsync(new BaseAccountRequest { Code = "valid-code", Password = "Str0ng!Passw0rd" });
 
             result.IsValid.Should().BeFalse();
             result.Errors.Should().Contain(e => e.ErrorMessage == "This password can not be used.");
+        }
+
+        [Fact]
+        public async Task Password_BlacklistLookupFails_PropagatesInsteadOfAllowing()
+        {
+            // Fail closed on the account flows too: a root-database outage must fail the request
+            // rather than let an unchecked password through.
+            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>()))
+                .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+            var act = async () => await Create().ValidateAsync(
+                new BaseAccountRequest { Code = "valid-code", Password = "Str0ng!Passw0rd" });
+
+            await act.Should().ThrowAsync<TimeoutException>();
         }
 
         [Fact]
@@ -146,3 +160,4 @@ namespace XUnitTest.IamTests.Accounts.Validators
         }
     }
 }
+

--- a/server/XUnitTest/IamTests/Accounts/Validators/ChangePasswordValidatorTests.cs
+++ b/server/XUnitTest/IamTests/Accounts/Validators/ChangePasswordValidatorTests.cs
@@ -1,4 +1,4 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using FluentAssertions;
 using Iam.DomainService.Accounts;
 using Iam.DomainService.Configurations;
@@ -26,7 +26,7 @@ namespace XUnitTest.IamTests.Accounts.Validators
             // Minimum-length regex: passwords of at least 8 chars are "strong".
             _config.Setup(c => c.GetConfigurationAsync())
                 .ReturnsAsync(new IamConfiguration { PasswordStrengthCheckerRegex = ".{8,}" });
-            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(false);
+            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>())).ReturnsAsync(false);
         }
 
         public void Dispose()
@@ -74,7 +74,7 @@ namespace XUnitTest.IamTests.Accounts.Validators
         [Fact]
         public async Task BlacklistedNewPassword_Fails()
         {
-            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync("NewPass123", It.IsAny<string>())).ReturnsAsync(true);
+            _iamRepo.Setup(r => r.CheckPasswordBlackListedAsync("NewPass123")).ReturnsAsync(true);
 
             var result = await Create().ValidateAsync(Req());
 
@@ -83,3 +83,4 @@ namespace XUnitTest.IamTests.Accounts.Validators
         }
     }
 }
+

--- a/server/XUnitTest/IamTests/Shared/IdentityAccessManagementRepositoryTests.cs
+++ b/server/XUnitTest/IamTests/Shared/IdentityAccessManagementRepositoryTests.cs
@@ -1,10 +1,13 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using FluentAssertions;
 using Iam.DomainService.Dtos;
 using Iam.DomainService.Entities;
 using Iam.DomainService.Services;
 using Iam.DomainService.Shared.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Moq;
 using XUnitTest.TestSupport;
@@ -18,7 +21,17 @@ namespace XUnitTest.IamTests.Shared
     /// </summary>
     public sealed class IdentityAccessManagementRepositoryTests
     {
+        private const string TestConnectionString = "mongodb://localhost:27017";
+        private const string TestRootDatabaseName = "BlocksRootDb";
+
         private readonly Mock<IDbContextProvider> _db = new();
+        private readonly Mock<IBlocksSecret> _secret = new();
+
+        public IdentityAccessManagementRepositoryTests()
+        {
+            _secret.SetupGet(s => s.DatabaseConnectionString).Returns(TestConnectionString);
+            _secret.SetupGet(s => s.RootDatabaseName).Returns(TestRootDatabaseName);
+        }
 
         private Mock<IMongoCollection<T>> Register<T>(IEnumerable<T>? items = null)
         {
@@ -28,7 +41,22 @@ namespace XUnitTest.IamTests.Shared
             return col;
         }
 
-        private IdentityAccessManagementRepository Sut() => new(_db.Object);
+        /// <summary>
+        /// The blacklist lives in the root database, reached through GetDatabase rather than the
+        /// tenant-scoped GetCollection the other fixtures use.
+        /// </summary>
+        private Mock<IMongoCollection<T>> RegisterBlackList<T>(IEnumerable<T>? items = null)
+        {
+            var col = MongoMock.Collection(items);
+            var database = MongoMock.Database();
+            MongoMock.OnDatabase(database, "BlackListInformations", col);
+            _db.Setup(d => d.GetDatabase(TestConnectionString, TestRootDatabaseName, false))
+                .Returns(database.Object);
+            return col;
+        }
+
+        private IdentityAccessManagementRepository Sut() =>
+            new(_db.Object, _secret.Object, NullLogger<IdentityAccessManagementRepository>.Instance);
 
         [Fact]
         public async Task GetIamConfigurationAsync_ReturnsMatch()
@@ -59,25 +87,134 @@ namespace XUnitTest.IamTests.Shared
             (await Sut().GetUserByIdAsync<User>("u1")).ItemId.Should().Be("u1");
         }
 
-        [Fact]
-        public async Task CheckPasswordBlackListedAsync_EmptyTenant_ReturnsFalse()
-        {
-            (await Sut().CheckPasswordBlackListedAsync("pw", " ")).Should().BeFalse();
-        }
+        // The former CheckPasswordBlackListedAsync_EmptyTenant_ReturnsFalse test has been removed
+        // rather than adapted. It asserted that a blank tenant id short-circuits to "not
+        // blacklisted", which is exactly the fail-open behaviour this change eliminates; keeping it
+        // green would have required reinstating the vulnerability. The replacement is
+        // CheckPasswordBlackListedAsync_NoTenantContext_StillChecks below.
 
         [Fact]
         public async Task CheckPasswordBlackListedAsync_Match_ReturnsTrue()
         {
-            Register(new[] { new BlackListInformation { Key = "password", Value = "pw" } });
-            (await Sut().CheckPasswordBlackListedAsync("pw", "tenant1")).Should().BeTrue();
+            RegisterBlackList(new[] { new BlackListInformation { Key = "password", Value = "pw" } });
+            (await Sut().CheckPasswordBlackListedAsync("pw")).Should().BeTrue();
         }
 
         [Fact]
         public async Task CheckPasswordBlackListedAsync_NoMatch_ReturnsFalse()
         {
-            var col = Register<BlackListInformation>();
+            var col = RegisterBlackList<BlackListInformation>();
             MongoMock.SetupCount(col, 0);
-            (await Sut().CheckPasswordBlackListedAsync("pw", "tenant1")).Should().BeFalse();
+            (await Sut().CheckPasswordBlackListedAsync("pw")).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task CheckPasswordBlackListedAsync_ResolvesTheRootDatabase()
+        {
+            RegisterBlackList(new[] { new BlackListInformation { Key = "password", Value = "pw" } });
+
+            await Sut().CheckPasswordBlackListedAsync("pw");
+
+            // The whole point of the fix: the lookup goes to the root database named by the secret,
+            // never to a tenant database, so one entry blocks the password for every tenant.
+            _db.Verify(d => d.GetDatabase(TestConnectionString, TestRootDatabaseName, false), Times.Once);
+            _db.Verify(d => d.GetCollection<BlackListInformation>(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CheckPasswordBlackListedAsync_NoTenantContext_StillChecks()
+        {
+            BlocksContext.SetContext(null);
+            RegisterBlackList(new[] { new BlackListInformation { Key = "password", Value = "pw" } });
+
+            // Without a tenant the old code returned false outright, leaving every context-free
+            // path unprotected.
+            (await Sut().CheckPasswordBlackListedAsync("pw")).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CheckPasswordBlackListedAsync_RootDatabaseUnreachable_Propagates()
+        {
+            var col = RegisterBlackList<BlackListInformation>();
+            col.Setup(c => c.CountDocumentsAsync(
+                    It.IsAny<FilterDefinition<BlackListInformation>>(),
+                    It.IsAny<CountOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+            // Fail closed: an outage must fail the request, not report the password as safe.
+            await Assert.ThrowsAsync<TimeoutException>(() => Sut().CheckPasswordBlackListedAsync("pw"));
+        }
+
+        /// <summary>
+        /// MongoMock.SetupIndexes returns void, so build the index manager here where the test needs
+        /// to assert against it.
+        /// </summary>
+        private static Mock<IMongoIndexManager<BlackListInformation>> RegisterIndexes(
+            Mock<IMongoCollection<BlackListInformation>> col)
+        {
+            var indexes = new Mock<IMongoIndexManager<BlackListInformation>>();
+            indexes.Setup(i => i.CreateOneAsync(
+                    It.IsAny<CreateIndexModel<BlackListInformation>>(),
+                    It.IsAny<CreateOneIndexOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync("ix");
+            col.Setup(c => c.Indexes).Returns(indexes.Object);
+            return indexes;
+        }
+
+        [Fact]
+        public async Task EnsureIndexesAsync_CreatesTheCompoundIndex()
+        {
+            var indexes = RegisterIndexes(RegisterBlackList<BlackListInformation>());
+
+            await Sut().EnsureIndexesAsync();
+
+            indexes.Verify(i => i.CreateOneAsync(
+                It.Is<CreateIndexModel<BlackListInformation>>(m =>
+                    m.Options.Name == "ix_key_value" && RendersAscendingKeyThenValue(m)),
+                It.IsAny<CreateOneIndexOptions>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        /// <summary>
+        /// The name alone would still pass if the keys were wrong or reversed, so render the
+        /// definition and check the actual ordered fields.
+        /// </summary>
+        private static bool RendersAscendingKeyThenValue(CreateIndexModel<BlackListInformation> model)
+        {
+            var registry = BsonSerializer.SerializerRegistry;
+            var rendered = model.Keys.Render(
+                new RenderArgs<BlackListInformation>(registry.GetSerializer<BlackListInformation>(), registry));
+
+            return rendered.ElementCount == 2
+                && rendered.GetElement(0).Name == "Key" && rendered.GetElement(0).Value == 1
+                && rendered.GetElement(1).Name == "Value" && rendered.GetElement(1).Value == 1;
+        }
+
+        [Fact]
+        public async Task EnsureIndexesAsync_SwallowsFailuresAndWarns()
+        {
+            var indexes = RegisterIndexes(RegisterBlackList<BlackListInformation>());
+            indexes.Setup(i => i.CreateOneAsync(
+                    It.IsAny<CreateIndexModel<BlackListInformation>>(),
+                    It.IsAny<CreateOneIndexOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("no permission"));
+
+            var logger = new Mock<ILogger<IdentityAccessManagementRepository>>();
+            var sut = new IdentityAccessManagementRepository(_db.Object, _secret.Object, logger.Object);
+
+            // A missing index costs speed, never correctness, so startup must survive this - but it
+            // must not vanish silently either, or a permanently missing index goes unnoticed.
+            await sut.EnsureIndexesAsync();
+
+            logger.Verify(l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
         }
 
         [Fact]
@@ -168,3 +305,4 @@ namespace XUnitTest.IamTests.Shared
         }
     }
 }
+

--- a/server/XUnitTest/IamTests/Users/CreateUserValidatorTests.cs
+++ b/server/XUnitTest/IamTests/Users/CreateUserValidatorTests.cs
@@ -1,4 +1,4 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using Iam.DomainService.Configurations;
@@ -30,7 +30,7 @@ namespace XUnitTest.IamTests.Users
             // Defaults: unique username/email, no blacklist, no password regex, single-org tenant.
             _userRepo.Setup(r => r.GetUserByUserNameOrgIdAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((User?)null!);
-            _userRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _userRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>()))
                 .ReturnsAsync(false);
             _configRepo.Setup(c => c.GetConfigurationAsync())
                 .ReturnsAsync(new IamConfiguration { PasswordStrengthCheckerRegex = string.Empty });
@@ -166,12 +166,28 @@ namespace XUnitTest.IamTests.Users
         [Fact]
         public async Task Password_Blacklisted_Fails()
         {
-            _userRepo.Setup(r => r.CheckPasswordBlackListedAsync("Password1!", It.IsAny<string>()))
+            _userRepo.Setup(r => r.CheckPasswordBlackListedAsync("Password1!"))
                 .ReturnsAsync(true);
             var req = ValidRequest();
             req.Password = "Password1!";
             var result = await Create().TestValidateAsync(req);
             result.ShouldHaveValidationErrorFor(x => x.Password);
+        }
+
+        [Fact]
+        public async Task Password_BlacklistLookupFails_PropagatesInsteadOfAllowing()
+        {
+            // Fail closed. If the root database cannot be reached the validator must not decide the
+            // password is fine; the exception has to escape and fail the request. This runs the real
+            // validator, so it would fail if the lookup were ever wrapped in a catch.
+            _userRepo.Setup(r => r.CheckPasswordBlackListedAsync(It.IsAny<string>()))
+                .ThrowsAsync(new TimeoutException("root database unreachable"));
+            var req = ValidRequest();
+            req.Password = "Password1!";
+
+            var act = async () => await Create().ValidateAsync(req);
+
+            await act.Should().ThrowAsync<TimeoutException>();
         }
 
         [Fact]
@@ -211,3 +227,4 @@ namespace XUnitTest.IamTests.Users
         }
     }
 }
+

--- a/server/XUnitTest/IamTests/Users/UserManagementMutationServiceTests.cs
+++ b/server/XUnitTest/IamTests/Users/UserManagementMutationServiceTests.cs
@@ -73,6 +73,21 @@ namespace XUnitTest.IamTests.Users
         // ---------- CreateUserAsync ----------
 
         [Fact]
+        public async Task CreateUser_ValidatorThrows_FailsTheRequestRatherThanAllowingIt()
+        {
+            // This service mocks its validator, so the assertion here is narrow but still worth
+            // pinning: whatever escapes validation must fail the request rather than be converted
+            // into a success or an ordinary validation error. The blacklist lookup itself is
+            // exercised against the real validator in CreateUserValidatorTests.
+            _createValidator.Setup(v => v.ValidateAsync(It.IsAny<CreateUserRequest>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+            var act = async () => await Create().CreateUserAsync(new CreateUserRequest { Email = "a@b.com", Password = "Passw0rd!" });
+
+            await act.Should().ThrowAsync<TimeoutException>();
+        }
+
+        [Fact]
         public async Task CreateUser_ValidationFails_ReturnsErrors()
         {
             _createValidator.Setup(v => v.ValidateAsync(It.IsAny<CreateUserRequest>(), It.IsAny<CancellationToken>()))

--- a/server/XUnitTest/IamTests/Users/UserRepositoryTests.cs
+++ b/server/XUnitTest/IamTests/Users/UserRepositoryTests.cs
@@ -1,4 +1,4 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using FluentAssertions;
 using Iam.DomainService.Dtos;
 using Iam.DomainService.Entities;
@@ -51,8 +51,8 @@ namespace XUnitTest.IamTests.Users
         [Fact]
         public async Task CheckPasswordBlackListedAsync_Delegates()
         {
-            _iam.Setup(r => r.CheckPasswordBlackListedAsync("pw", "t1")).ReturnsAsync(true);
-            (await Sut().CheckPasswordBlackListedAsync("pw", "t1")).Should().BeTrue();
+            _iam.Setup(r => r.CheckPasswordBlackListedAsync("pw")).ReturnsAsync(true);
+            (await Sut().CheckPasswordBlackListedAsync("pw")).Should().BeTrue();
         }
 
         [Fact]
@@ -511,3 +511,4 @@ namespace XUnitTest.IamTests.Users
         }
     }
 }
+


### PR DESCRIPTION
## Ticket

#451 — https://github.com/SELISEdigitalplatforms/blocks-iam/issues/451

## What changed

The password blacklist is now enforced globally instead of per tenant.

`CheckPasswordBlackListedAsync` resolved `BlackListInformations` inside **the caller's own tenant database**. A password blacklisted for one tenant was therefore rejected for that tenant and silently accepted by every other one, and a tenant with no document of its own was unprotected no matter what had been blacklisted globally. The lookup also **returned `false` outright when no tenant id was available**, so any code path without tenant context skipped the check entirely and reported the password as safe.

It now reads the single global collection in the root database (`IBlocksSecret.RootDatabaseName`), so one entry blocks a password everywhere, and the tenant id is dropped from the call chain because it no longer takes part in the decision.

### Two things left out on purpose

The lookup has **no tenant guard and no `try/catch`**. Both omissions are the fix:

- The tenant guard was the second fail-open hole (C3).
- Catching here would mean an unreachable root database reads as "not blacklisted" — the same failure being replaced, one layer up. An outage now fails the request (C1), and tests pin that at both the repository and the validator level.

`EnsureIndexesAsync` *does* swallow and log, and that asymmetry is deliberate: a missing index costs speed, never correctness, so it must not stop a service from starting (C5).

### Notes for the reviewer

- **The Genesis dependency was verified, not assumed.** The design needs `IDbContextProvider.GetDatabase(connectionString, databaseName, bool)`, which **nothing in this repo called before**. Rather than let the build discover it, a throwaway file calling that overload was compiled against `Iam.DomainService.csproj` (exit 0) and removed. The `MongodbCertificateProvider`-style raw `MongoClient` fallback was consequently dropped from the plan entirely.
- **One spec path is wrong.** §2 places `DeviceAuthorizationRepository` — the pattern to mirror — under `Iam.DomainService/Shared/Services/`. It is actually at `Authentication.DomainService/Oidc/Repositories/`, and `SecurityRepository` is under `Authentication.DomainService/Security/Repositories/`. The worker location the spec gives *is* correct, so `BlacklistIndexWorker` sits beside `DeviceCleanupWorker`.
- **A deleted test, deliberately.** `CheckPasswordBlackListedAsync_EmptyTenant_ReturnsFalse` asserted that a blank tenant id short-circuits to "not blacklisted" — precisely the fail-open behaviour C3 removes. It is **deleted, not adapted**, with a comment in its place explaining why; making it pass again would have meant reinstating half the vulnerability. `CheckPasswordBlackListedAsync_NoTenantContext_StillChecks` replaces it.
- **`BackgroundService.StartAsync` does not invoke `ExecuteAsync` on this framework version** — the host decides when it runs. My first worker tests were therefore racing a continuation that never happened, and the "doesn't block startup" one would have passed even if the worker crashed asynchronously. The worker's logic is now a public `EnsureIndexesOnceAsync` that `ExecuteAsync` delegates to, so the tests drive behaviour this repo owns rather than the host's scheduling.
- **The DI test was strengthened.** The existing check asserted only that *some* `IHostedService` was registered, which already passed thanks to `DeviceCleanupWorker` and so could never have caught the new worker being unwired. Both descriptors are now asserted specifically.
- **Four processes-worth of behaviour, one worker.** `RegisterAllServices()` is called by both the Api and the Worker, so `BlacklistIndexWorker` runs in both. That is the ticket's own decision (A1) and is safe: creating an index that already exists is a no-op.

## Testing

- **Full suite: 2063 tests, 2063 passing, 0 failing** (2052 at baseline; 12 added, 1 deleted). Count read from the TRX result file rather than inferred from the exit code.
- `dotnet build server/BlocksIAM.sln` → exit 0. Every changed file is under `server/`; no client change.
- New coverage, each tied to a criterion:
  - `CheckPasswordBlackListedAsync_ResolvesTheRootDatabase` — asserts `GetDatabase` was called with the secret's connection string **and** root database name, and that the tenant-scoped `GetCollection` was **never** used (H5).
  - `..._NoTenantContext_StillChecks` — with `BlocksContext` null, the check still runs and still blocks (C3).
  - `..._RootDatabaseUnreachable_Propagates` — a timeout escapes rather than reading as safe (C1).
  - `Password_BlacklistLookupFails_PropagatesInsteadOfAllowing` in **both** `CreateUserValidatorTests` and `BaseAccountValidatorTests` — these run the **real** validators against a throwing repository, so they would fail if the lookup were ever wrapped in a catch.
  - `EnsureIndexesAsync_CreatesTheCompoundIndex` — renders the key definition and asserts the ordered fields are ascending `Key` then `Value`, not merely the index name (C4).
  - `EnsureIndexesAsync_SwallowsFailuresAndWarns` — survives failure *and* logs a warning, so a permanently missing index cannot pass unnoticed (C5).
  - Three `BlacklistIndexWorker` tests, and the specific-descriptor DI assertions.
- **e2e:** not executed. §7 needs three provisioned tenants, a live Mongo seeded with a root database, and a network-partition step; this delivery does not provision or mutate environments. Every §7 step has an equivalent unit test except the concurrent-startup index check (step 7) and the restricted-role check (step 8, which §7 already marks optional). **The walkthrough still needs a human pass before merge.**

## Review

codex (gpt-5.6-sol, high effort): 2 cycles on the plan, 2 cycles on the final diff. Self-review: 2 cycles.

Plan review raised 6 majors and 2 minors. The most useful: it refused to accept "the build will tell us" about the Genesis overload, which led to the compile probe above; then caught that the probe had validated the **three**-argument call while the plan's code sample wrote a **two**-argument one. It also found that the hosted-service test could never detect missing wiring, and that fail-closed was pinned only at repository scope when the check actually crosses four request boundaries.

Code review cycle 1 raised 2 minors, both fair: the request-boundary test mocked the validator, so it never exercised a blacklist lookup and would have passed with the vulnerability reinstated; and the index test checked only the index *name*, not its ordered keys. Both fixed — the first by adding tests that use the real validators. Cycle 2 came back clean.

No unresolved critical findings.
