### PR TITLE
[#427] SPEC [BE] — Expose account lockout state on the Users API (Phase 1 of 2)

### DIFF
--- a/server/Iam.DomainService/Shared/Dtos/GetAccounts.cs
+++ b/server/Iam.DomainService/Shared/Dtos/GetAccounts.cs
@@ -33,6 +33,13 @@ namespace Iam.DomainService.Dtos
         public UserCreationType UserCreationType { get; set; }
         public int LogInCount { get; set; }
         public DateTime LastLoggedInTime { get; set; }
+
+        /// <summary>
+        /// When the account's lockout expires, or null if it has never been locked out. Read-only
+        /// here: this DTO is a projection of User and nothing in the query path writes it.
+        /// LockoutCount and LastLockoutUtc are deliberately not projected - no consumer yet.
+        /// </summary>
+        public DateTime? LockoutUntilUtc { get; set; }
         public string LastLoggedInDeviceInfo { get; set; } = string.Empty;
         public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
     }

--- a/server/Iam.DomainService/Users/Services/UserManagementQueryService.cs
+++ b/server/Iam.DomainService/Users/Services/UserManagementQueryService.cs
@@ -8,14 +8,21 @@ namespace Iam.DomainService.Users
     {
         private readonly ILogger<UserManagementQueryService> _logger;
         private readonly IUserRepository _userRepository;
+        private readonly TimeProvider _timeProvider;
 
         public UserManagementQueryService(
             ILogger<UserManagementQueryService> logger,
-            IUserRepository userRepository
+            IUserRepository userRepository,
+            // Optional with a System fallback rather than a DI registration: this service is
+            // registered from Authentication.DomainService's RegisterAllServices (the root the API
+            // actually calls), so a required dependency registered elsewhere would be unresolvable
+            // at runtime while every unit test still passed.
+            TimeProvider? timeProvider = null
         )
         {
             _logger = logger;
             _userRepository = userRepository;
+            _timeProvider = timeProvider ?? TimeProvider.System;
         }
 
         public async Task<bool> IsUserAvailableAsync(IsEmailAvailableRequest query)
@@ -48,7 +55,13 @@ namespace Iam.DomainService.Users
 
             var (data, count) = await _userRepository.GetUsersAsync<GetAccounts, GetUsersRequest>(query);
 
-            var selectedUsers = data?.Select(user => MapToListAccountFields(user))
+            // One instant for the whole response, per the data contract's "server UTC time at
+            // response construction" - so every item in a page is judged against the same moment.
+            // Lazy so an empty page never reads the clock at all: C2 says no lockout computation is
+            // attempted when nothing matches, and a test with a throwing clock proves it.
+            var asOfUtc = new Lazy<DateTime>(() => _timeProvider.GetUtcNow().UtcDateTime);
+
+            var selectedUsers = data?.Select(user => MapToListAccountFields(user, asOfUtc.Value))
             .Where(user => user.Count > 0).AsQueryable() ?? Enumerable.Empty<Dictionary<string, object>>().AsQueryable();
 
             _logger.LogInformation("User get end");
@@ -87,7 +100,11 @@ namespace Iam.DomainService.Users
             var user = await _userRepository.GetUserByIdAsync<GetAccounts>(userId);
             var contextOrgId = string.IsNullOrWhiteSpace(organizationId) ? (bc?.OrganizationId ?? "default") : organizationId;
 
-            var data = user == null ? null : MapToSingleUserFields(user, contextOrgId);
+            // Read only when there is a user to map - a missing user must not trigger any lockout
+            // computation (C4), and a throwing clock in the tests proves it does not.
+            var data = user == null
+                ? null
+                : MapToSingleUserFields(user, contextOrgId, _timeProvider.GetUtcNow().UtcDateTime);
 
             if(contextOrgId == "default")
             {
@@ -103,7 +120,7 @@ namespace Iam.DomainService.Users
             };
         }
 
-        private static Dictionary<string, object> MapToListAccountFields(GetAccounts user)
+        private static Dictionary<string, object> MapToListAccountFields(GetAccounts user, DateTime asOfUtc)
         {
             return new Dictionary<string, object>
             {
@@ -120,7 +137,9 @@ namespace Iam.DomainService.Users
                 ["lastLoggedInTime"] = user.LastLoggedInTime,
                 ["loginCount"] = user.LogInCount,
                 ["createdDate"] = user.CreatedDate,
-                ["roles"] = user.Roles
+                ["roles"] = user.Roles,
+                ["lockoutUntilUtc"] = user.LockoutUntilUtc,
+                ["isLockedOut"] = IsLockedOut(user.LockoutUntilUtc, asOfUtc)
             };
         }
 
@@ -160,7 +179,7 @@ namespace Iam.DomainService.Users
             };
         }
 
-        private static Dictionary<string, object> MapToSingleUserFields(GetAccounts user, string contextOrgId)
+        private static Dictionary<string, object> MapToSingleUserFields(GetAccounts user, string contextOrgId, DateTime asOfUtc)
         {
             if (!user.OrganizationIds.Contains(contextOrgId) && contextOrgId != "default")
             {
@@ -192,8 +211,28 @@ namespace Iam.DomainService.Users
                 ["logInCount"] = user.LogInCount,
                 ["lastLoggedInTime"] = user.LastLoggedInTime,
                 ["lastLoggedInDeviceInfo"] = user.LastLoggedInDeviceInfo ?? string.Empty,
-                ["organizationIds"] = user.OrganizationIds
+                ["organizationIds"] = user.OrganizationIds,
+                // Added AFTER the cross-org early return above, so an out-of-org caller still gets
+                // an empty dictionary and no lockout state leaks across organizations.
+                ["lockoutUntilUtc"] = user.LockoutUntilUtc,
+                ["isLockedOut"] = IsLockedOut(user.LockoutUntilUtc, asOfUtc)
             };
         }
+
+        /// <summary>
+        /// Whether the account is locked out as of <paramref name="asOfUtc"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately strict &gt;, matching the check the authentication flows perform before
+        /// refusing a login (e.g. PasswordAuthenticationService.cs:58), so what this API reports
+        /// agrees with what actually blocks a sign-in.
+        ///
+        /// This is NOT a system-wide source of truth: authentication still inlines the same
+        /// expression in around six places, and unifying them would mean editing authentication
+        /// code paths, which is out of scope for a read-only exposure change. If that predicate ever
+        /// moves, this must move with it - no test here can catch that divergence.
+        /// </remarks>
+        private static bool IsLockedOut(DateTime? lockoutUntilUtc, DateTime asOfUtc) =>
+            lockoutUntilUtc.HasValue && lockoutUntilUtc.Value > asOfUtc;
     }
 }

--- a/server/XUnitTest/Api/IamControllerTests.cs
+++ b/server/XUnitTest/Api/IamControllerTests.cs
@@ -638,5 +638,30 @@ namespace XUnitTest.ApiTests
 
             result.Should().BeSameAs(response);
         }
+
+        // ---------------------------------------------------------------------------------
+        // #427 — C3: this phase must not change or weaken the existing authorization.
+        // ---------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(nameof(IamController.GetUsers))]
+        [InlineData(nameof(IamController.GetUser))]
+        public void UsersEndpoints_StillRequireTheIamUsersPermission(string action)
+        {
+            // The two endpoints #427 touches must keep the permission they had. Adding response
+            // fields cannot weaken authz by itself, but the attribute is one careless edit away from
+            // the mapper work, and C3 is explicit that authorization is unchanged.
+            //
+            // Stated limit: this proves the ATTRIBUTE survived, not that an unauthorised caller gets
+            // the same status and body - that needs an HTTP boundary, which these tests do not have.
+            var method = typeof(IamController).GetMethod(action)!;
+
+            var attribute = method.GetCustomAttributes(typeof(ProtectedEndPointAttribute), true)
+                                  .Cast<ProtectedEndPointAttribute>()
+                                  .SingleOrDefault();
+
+            attribute.Should().NotBeNull($"{action} must stay behind an explicit permission");
+            attribute!.ResourceName.Should().Be("blocks-iam::iam::users");
+        }
     }
 }

--- a/server/XUnitTest/IamTests/Users/UserManagementQueryServiceTests.cs
+++ b/server/XUnitTest/IamTests/Users/UserManagementQueryServiceTests.cs
@@ -4,7 +4,13 @@ using Iam.DomainService.Dtos;
 using Iam.DomainService.Entities;
 using Iam.DomainService.Users;
 using Iam.DomainService.Users.RequestModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using System.Text.Json;
 using Moq;
 
 namespace XUnitTest.IamTests.Users
@@ -136,6 +142,428 @@ namespace XUnitTest.IamTests.Users
             var result = await Create().GetUserAsync("u9", "org-42");
 
             result.Data.Should().NotContainKey("OrganizationsRoles");
+        }
+
+        // =====================================================================================
+        // #427 — lockout state exposure. Phase 1 of 2; the FE phase is built against these keys.
+        // =====================================================================================
+
+        /// <summary>Clock the service reads once per response, so exact-equality cases are arrangeable.</summary>
+        private sealed class FixedClock(DateTime utcNow) : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
+        }
+
+        /// <summary>A clock that fails the test if it is read at all.</summary>
+        private sealed class ThrowingClock : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() =>
+                throw new InvalidOperationException("the clock must not be read when there is nothing to map");
+        }
+
+        private static readonly DateTime Now = new(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc);
+
+        private UserManagementQueryService CreateAt(DateTime utcNow) =>
+            new(NullLogger<UserManagementQueryService>.Instance, _repo.Object, new FixedClock(utcNow));
+
+        private static GetAccounts Account(string id, DateTime? lockoutUntilUtc) => new()
+        {
+            ItemId = id,
+            Email = id + "@e.com",
+            OrganizationIds = new List<string> { "default" },
+            LockoutUntilUtc = lockoutUntilUtc
+        };
+
+        [Fact]
+        public async Task GetUser_FutureLockout_ReportsLockedOut()
+        {
+            // H1
+            InstallContext();
+            var until = Now.AddHours(1);
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u1")).ReturnsAsync(Account("u1", until));
+
+            var result = await CreateAt(Now).GetUserAsync("u1", "default");
+
+            result.Data!["lockoutUntilUtc"].Should().Be(until);
+            result.Data["isLockedOut"].Should().Be(true);
+        }
+
+        [Fact]
+        public async Task GetUser_NeverLockedOut_KeyIsPresentAndNull()
+        {
+            // H2. Presence is asserted separately from the value: a dropped key breaks the Phase 2
+            // contract exactly as badly as a wrong one, and `Should().BeNull()` alone passes for a
+            // key that was never written.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u2")).ReturnsAsync(Account("u2", null));
+
+            var result = await CreateAt(Now).GetUserAsync("u2", "default");
+
+            result.Data.Should().ContainKey("lockoutUntilUtc");
+            result.Data!["lockoutUntilUtc"].Should().BeNull();
+            result.Data["isLockedOut"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task GetUser_ExpiredLockout_ReturnsInstantVerbatimButNotLockedOut()
+        {
+            // H3. The raw instant is still reported even though the window has passed - the field is
+            // not cleared until a login attempt, and the contract says "verbatim, no transformation".
+            InstallContext();
+            var until = Now.AddHours(-1);
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u3")).ReturnsAsync(Account("u3", until));
+
+            var result = await CreateAt(Now).GetUserAsync("u3", "default");
+
+            result.Data!["lockoutUntilUtc"].Should().Be(until);
+            result.Data["isLockedOut"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task GetUsers_EachItemComputedIndependently()
+        {
+            // H4. Three states in ONE response: a mapper that computes once and reuses the answer,
+            // or that reads the first item's value, fails here and nowhere else.
+            var future = Now.AddHours(1);
+            var past = Now.AddHours(-1);
+            var accounts = new List<GetAccounts>
+            {
+                Account("locked", future), Account("never", null), Account("expired", past)
+            }.AsQueryable();
+            _repo.Setup(r => r.GetUsersAsync<GetAccounts, GetUsersRequest>(It.IsAny<GetUsersRequest>()))
+                .ReturnsAsync((accounts, 3L));
+
+            var items = (await CreateAt(Now).GetUsersAsync(new GetUsersRequest())).Data.ToList();
+
+            items[0]["lockoutUntilUtc"].Should().Be(future);
+            items[0]["isLockedOut"].Should().Be(true);
+            items[1]["lockoutUntilUtc"].Should().BeNull();
+            items[1]["isLockedOut"].Should().Be(false);
+            items[2]["lockoutUntilUtc"].Should().Be(past);
+            items[2]["isLockedOut"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task GetUser_LockoutExactlyNow_IsNotLockedOut()
+        {
+            // C1. Strictly greater-than, matching the authentication check. Only arrangeable because
+            // the clock is injected: against a live DateTime.UtcNow a test can never hit equality,
+            // and both > and >= would return false - passing with the predicate wrong.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u4")).ReturnsAsync(Account("u4", Now));
+
+            var result = await CreateAt(Now).GetUserAsync("u4", "default");
+
+            result.Data!["isLockedOut"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task GetUser_OneTickAfterNow_IsLockedOut()
+        {
+            // The other side of the C1 boundary, so "always false" cannot pass.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u5"))
+                .ReturnsAsync(Account("u5", Now.AddTicks(1)));
+
+            var result = await CreateAt(Now).GetUserAsync("u5", "default");
+
+            result.Data!["isLockedOut"].Should().Be(true);
+        }
+
+        [Fact]
+        public async Task GetUsers_EmptyResult_IsUnchangedAndErrorFree()
+        {
+            // C2. Does not claim to prove "no lockout computation" - the helper is private and
+            // there are no items to map regardless.
+            _repo.Setup(r => r.GetUsersAsync<GetAccounts, GetUsersRequest>(It.IsAny<GetUsersRequest>()))
+                .ReturnsAsync((Enumerable.Empty<GetAccounts>().AsQueryable(), 0L));
+
+            var result = await CreateAt(Now).GetUsersAsync(new GetUsersRequest());
+
+            result.TotalCount.Should().Be(0);
+            result.Data.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task GetUsers_EmptyResult_AttemptsNoLockoutComputation()
+        {
+            // C2's literal clause: "no lockout computation is attempted". Asserting the output alone
+            // could not show that - an implementation that computed and discarded would pass. A clock
+            // that throws when touched is what actually demonstrates it.
+            _repo.Setup(r => r.GetUsersAsync<GetAccounts, GetUsersRequest>(It.IsAny<GetUsersRequest>()))
+                .ReturnsAsync((Enumerable.Empty<GetAccounts>().AsQueryable(), 0L));
+
+            var svc = new UserManagementQueryService(
+                NullLogger<UserManagementQueryService>.Instance, _repo.Object, new ThrowingClock());
+
+            var result = await svc.GetUsersAsync(new GetUsersRequest());
+
+            result.Data.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task GetUser_MissingUser_AttemptsNoLockoutComputation()
+        {
+            // C4's second, genuinely satisfiable half. (Its first half - "the existing not-found
+            // error" - describes behaviour this endpoint does not have; see the PR.)
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("nope")).ReturnsAsync((GetAccounts)null!);
+
+            var svc = new UserManagementQueryService(
+                NullLogger<UserManagementQueryService>.Instance, _repo.Object, new ThrowingClock());
+
+            // Non-default org: the default-org path dereferences null before returning, which is the
+            // pre-existing defect this phase deliberately leaves alone.
+            var result = await svc.GetUserAsync("nope", "org-42");
+
+            result.Data.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetUser_MissingUser_DefaultOrg_ThrowsToday_KnownPreExistingDefect()
+        {
+            // Pins ACTUAL behaviour, not desired. C4 says a non-existent id returns "the existing
+            // not-found error" - there is none. On the default-org path GetUserAsync builds a null
+            // `data` and then dereferences it to add OrganizationsRoles, so the caller gets a 500.
+            //
+            // #427 deliberately does not fix this: introducing a 404 changes the endpoint's status
+            // code and controller response type, which contradicts C6 and the ticket's out-of-scope
+            // list. Asserted so a future fix has to flip this test deliberately rather than silently,
+            // and so the C4 discrepancy is visible in the suite and not only in the PR.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("nope")).ReturnsAsync((GetAccounts)null!);
+
+            var act = async () => await CreateAt(Now).GetUserAsync("nope", "default");
+
+            await act.Should().ThrowAsync<NullReferenceException>();
+        }
+
+        [Fact]
+        public async Task GetUser_OutOfOrg_StaysEmptyAndLeaksNoLockoutState()
+        {
+            // The cross-org guard. The pre-existing test only checked that OrganizationsRoles was
+            // absent, which would still pass if the lockout keys leaked - so this asserts the
+            // response is EXACTLY empty for a caller outside the user's organizations.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u6"))
+                .ReturnsAsync(new GetAccounts
+                {
+                    ItemId = "u6",
+                    Email = "u6@e.com",
+                    OrganizationIds = new List<string> { "org-1" },
+                    LockoutUntilUtc = Now.AddHours(1)
+                });
+
+            var result = await CreateAt(Now).GetUserAsync("u6", "org-42");
+
+            result.Data.Should().BeEmpty();
+            result.Data.Should().NotContainKey("lockoutUntilUtc");
+            result.Data.Should().NotContainKey("isLockedOut");
+        }
+
+        [Fact]
+        public async Task GetUser_ReturnsWhateverTheRepositoryReturned()
+        {
+            // C5. Proves there is no service-level caching of lockout state between calls. It does
+            // NOT prove the absence of locking - an implementation adding one would pass too.
+            InstallContext();
+            _repo.SetupSequence(r => r.GetUserByIdAsync<GetAccounts>("u7"))
+                .ReturnsAsync(Account("u7", Now.AddHours(1)))
+                .ReturnsAsync(Account("u7", null));
+
+            var svc = CreateAt(Now);
+            (await svc.GetUserAsync("u7", "default")).Data!["isLockedOut"].Should().Be(true);
+            (await svc.GetUserAsync("u7", "default")).Data!["isLockedOut"].Should().Be(false);
+        }
+
+        [Fact]
+        public async Task GetAccount_MeEndpoint_DoesNotGainLockoutFields()
+        {
+            // Scope boundary: GET /me uses MapToSingleAccountFields and is out of scope, so adding
+            // the fields there too would be an unrequested API change.
+            InstallContext();
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("user-1"))
+                .ReturnsAsync(Account("user-1", Now.AddHours(1)));
+
+            var result = await CreateAt(Now).GetAccountAsync();
+
+            // The COMPLETE key set, not merely the absence of the two new ones: this endpoint is out
+            // of scope, so any drift in its shape - a gained field or a lost one - should fail here.
+            result.Data!.Keys.Should().BeEquivalentTo(new[]
+            {
+                "itemId", "createdDate", "lastUpdatedDate", "language", "salutation", "firstName",
+                "lastName", "email", "phoneNumber", "roles", "permissions", "active", "status",
+                "isVerified", "profileImageUrl", "mfaEnabled", "isMfaVerified", "userMfaType",
+                "externalIdentities", "attributes", "logInCount", "lastLoggedInTime",
+                "lastLoggedInDeviceInfo", "organizationId"
+            });
+        }
+
+        [Fact]
+        public async Task GetUsers_ListShape_IsExactlyTheExistingKeysPlusTwo()
+        {
+            // H6 + C6 for the list. Asserts the COMPLETE dictionary with distinctive values, not
+            // just the key names: a key-set comparison alone would pass if `active` silently became
+            // the string "true".
+            var account = new GetAccounts
+            {
+                ItemId = "u8", FirstName = "Ada", LastName = "Lovelace", Email = "ada@e.com",
+                UserName = "ada", Active = true, IsVerified = true, ProfileImageUrl = "http://img",
+                MfaEnabled = true, LogInCount = 7, LastLoggedInTime = Now.AddDays(-1),
+                CreatedDate = Now.AddDays(-30), LockoutUntilUtc = null,
+                Roles = new Dictionary<string, List<string>> { { "default", new List<string> { "admin" } } }
+            };
+            _repo.Setup(r => r.GetUsersAsync<GetAccounts, GetUsersRequest>(It.IsAny<GetUsersRequest>()))
+                .ReturnsAsync((new[] { account }.AsQueryable(), 1L));
+
+            var item = (await CreateAt(Now).GetUsersAsync(new GetUsersRequest())).Data.Single();
+
+            item.Should().BeEquivalentTo(new Dictionary<string, object?>
+            {
+                ["itemId"] = "u8",
+                ["firstName"] = "Ada",
+                ["lastName"] = "Lovelace",
+                ["email"] = "ada@e.com",
+                ["userName"] = "ada",
+                ["active"] = true,
+                ["status"] = account.Status,
+                ["isVerified"] = true,
+                ["profileImageUrl"] = "http://img",
+                ["mfaEnabled"] = true,
+                ["lastLoggedInTime"] = account.LastLoggedInTime,
+                ["loginCount"] = 7,
+                ["createdDate"] = account.CreatedDate,
+                ["roles"] = account.Roles,
+                ["lockoutUntilUtc"] = null,
+                ["isLockedOut"] = false
+            });
+        }
+
+        [Fact]
+        public async Task GetUser_DetailShape_IsExactlyTheExistingKeysPlusTwo()
+        {
+            // H6 + C6 for the detail endpoint, including the default-org extras.
+            InstallContext();
+            var account = new GetAccounts
+            {
+                ItemId = "u9", Language = "en", Salutation = "Ms", FirstName = "Grace",
+                LastName = "Hopper", Email = "grace@e.com", PhoneNumber = "123",
+                Active = true, IsVerified = true, ProfileImageUrl = "http://img2",
+                MfaEnabled = true, IsMfaVerified = true, LogInCount = 3,
+                LastLoggedInTime = Now.AddDays(-2), LastLoggedInDeviceInfo = "cli",
+                CreatedDate = Now.AddDays(-10), LastUpdatedDate = Now.AddDays(-1),
+                OrganizationIds = new List<string> { "default" },
+                LockoutUntilUtc = Now.AddHours(2),
+                Roles = new Dictionary<string, List<string>> { { "default", new List<string> { "admin" } } },
+                Permissions = new Dictionary<string, List<string>> { { "default", new List<string> { "read" } } }
+            };
+            _repo.Setup(r => r.GetUserByIdAsync<GetAccounts>("u9")).ReturnsAsync(account);
+
+            var data = (await CreateAt(Now).GetUserAsync("u9", "default")).Data;
+
+            data.Should().BeEquivalentTo(new Dictionary<string, object?>
+            {
+                ["itemId"] = "u9",
+                ["createdDate"] = account.CreatedDate,
+                ["lastUpdatedDate"] = account.LastUpdatedDate,
+                ["language"] = "en",
+                ["salutation"] = "Ms",
+                ["firstName"] = "Grace",
+                ["lastName"] = "Hopper",
+                ["email"] = "grace@e.com",
+                ["phoneNumber"] = "123",
+                ["roles"] = account.Roles["default"],
+                ["permissions"] = account.Permissions["default"],
+                ["active"] = true,
+                ["status"] = account.Status,
+                ["isVerified"] = true,
+                ["profileImageUrl"] = "http://img2",
+                ["mfaEnabled"] = true,
+                ["isMfaVerified"] = true,
+                ["userMfaType"] = account.UserMfaType,
+                ["externalIdentities"] = account.ExternalIdentities,
+                ["attributes"] = account.Attributes,
+                ["logInCount"] = 3,
+                ["lastLoggedInTime"] = account.LastLoggedInTime,
+                ["lastLoggedInDeviceInfo"] = "cli",
+                ["organizationIds"] = account.OrganizationIds,
+                ["lockoutUntilUtc"] = account.LockoutUntilUtc,
+                ["isLockedOut"] = true,
+                ["OrganizationsRoles"] = account.Roles,
+                ["OrganizationsPermissions"] = account.Permissions
+            });
+        }
+
+        [Fact]
+        public void GetAccounts_HydratesLockoutUntilUtc_AcrossTheBsonBoundary()
+        {
+            // The service tests all hand GetAccounts straight to a mock, so none of them prove a
+            // PERSISTED value reaches the API. Both repository paths project with
+            // Builders<User>.Projection.As<GetAccounts>(), which is a whole-document deserialise, so
+            // this round-trips real BSON rather than going through a mock that would prove nothing.
+            var until = new DateTime(2026, 8, 19, 15, 0, 0, DateTimeKind.Utc);
+            var user = new User { ItemId = "u10", Email = "u10@e.com", LockoutUntilUtc = until };
+
+            var bson = user.ToBsonDocument();
+            var projected = BsonSerializer.Deserialize<GetAccounts>(bson);
+
+            projected.ItemId.Should().Be("u10");
+            projected.LockoutUntilUtc.Should().Be(until);
+        }
+
+        [Fact]
+        public void Service_IsConstructable_WithoutATimeProviderRegistration()
+        {
+            // #427 added a TimeProvider dependency. The danger is activation, not registration: this
+            // service is registered from Authentication.DomainService's RegisterAllServices - the
+            // root Api/Program.cs actually calls - NOT from Iam.DomainService's
+            // RegisterSharedServices, which only its own unit tests use. Had TimeProvider been a
+            // required parameter registered in the wrong root, the API would have failed to build
+            // the controller at runtime while every service-level test here stayed green.
+            //
+            // Deliberately NOT resolved from the full RegisterAllServices graph: that needs
+            // host-level Genesis services (IDbContextProvider and friends) which no unit test has.
+            // This asserts the thing that is actually in doubt - that MS DI can activate the service
+            // with NO TimeProvider registered anywhere, via the optional-parameter fallback.
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(new Mock<IUserRepository>().Object);
+            services.AddSingleton<IUserManagementQueryService, UserManagementQueryService>();
+
+            using var provider = services.BuildServiceProvider();
+
+            provider.GetRequiredService<IUserManagementQueryService>().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void LockoutFields_SerializeToTheWireContractPhaseTwoExpects()
+        {
+            // Every other test here inspects a Dictionary<string, object>, all of which pass even if
+            // HTTP serialisation drops the null key or formats the timestamp wrongly - and Phase 2 is
+            // built against the JSON, not the dictionary.
+            //
+            // Options are RESOLVED from a real MVC registration rather than constructed, so a
+            // configured naming policy or converter would show up here. Measured on this stack:
+            // DefaultIgnoreCondition = Never (so a null value keeps its key), camelCase property
+            // policy, no converters. Residual limit, stated rather than papered over: the API layers
+            // its MVC setup through Genesis's ConfigureApi, which needs host services this test does
+            // not have - so if Genesis ever added a converter or a DictionaryKeyPolicy, only a hosted
+            // response test would catch it.
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddControllers();
+            using var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
+
+            var lockedJson = JsonSerializer.Serialize(
+                new Dictionary<string, object?> { ["lockoutUntilUtc"] = new DateTime(2026, 8, 19, 15, 0, 0, DateTimeKind.Utc) },
+                options);
+            lockedJson.Should().Contain("2026-08-19T15:00:00Z");
+
+            var neverJson = JsonSerializer.Serialize(
+                new Dictionary<string, object?> { ["lockoutUntilUtc"] = null }, options);
+            neverJson.Should().Contain("\"lockoutUntilUtc\":null",
+                "a dropped null key would silently break the Phase 2 contract");
         }
     }
 }


### PR DESCRIPTION
Refs #427 — https://github.com/SELISEdigitalplatforms/blocks-iam/issues/427

Phase 1 of 2. Adds `lockoutUntilUtc` and `isLockedOut` to `POST /api/iam/users` list items and `GET /api/iam/users/{id}`, so [blocks-os#434](https://github.com/SELISEdigitalplatforms/blocks-os/issues/434) can render a "Locked out" badge against them. Read-only and additive throughout: no writes, no new endpoint, no DB change, no change to authorization or to how lockout is set or cleared.

## ⚠️ C4 is NOT satisfied — this ticket is not fully complete

C4 requires a non-existent id to *"return the existing not-found error, unchanged by this phase"*. **There is no such error.** What the endpoint does today:

- **default-org context** — `GetUserAsync` builds a null `data`, then dereferences it to attach `OrganizationsRoles`, so the caller gets a **500**. The global exception middleware cannot reinterpret a generic `NullReferenceException` as "not found".
- **any other org context** — returns `Data = null`, which the typed action serialises as **HTTP 200**.
- and omitting `organizationId` does **not** mean "default" — it inherits `BlocksContext.OrganizationId`, so which of the two you get depends on the caller.

I did **not** add a 404. That changes the endpoint's status code and its controller response type, which contradicts C6 (*"SHALL NOT break an existing consumer"* — anything relying on today's 200-with-null breaks) and the ticket's own out-of-scope list, converting a read-only additive change into a behaviour change. Both current behaviours are pinned by tests named as known defects, so a future fix has to flip them deliberately.

**C4 needs a spec amendment or an explicit waiver**, and the definition of done is not met until then. The other eleven criteria are delivered. A follow-up is raised for the null-deref itself, since a 500 on a missing id is a defect whatever C4 intended.

## What the ticket got wrong about the code

**The mappers don't read `User`.** They read `GetAccounts`, a projection DTO that had no `LockoutUntilUtc`. The ticket frames the work as "adds keys to the dictionaries the mappers build", which skips the fact that the field has to reach the projection first. Both repository paths use `Builders<User>.Projection.As<T>()` — whole-document deserialise — so adding the property suffices, and a **BSON round-trip test** pins that rather than assuming it.

**"Reuse the exact predicate" isn't possible as written.** There is no shared helper: `LockoutUntilUtc.HasValue && LockoutUntilUtc.Value > DateTime.UtcNow` is inlined in about six places across `Authentication.DomainService`. This adds one private helper used by both new mappers, and its documentation says explicitly that it is **not** a system-wide source of truth — if authentication's predicate ever moves, this must move with it, and **no test here can catch that divergence**.

## Why the clock is injected

`isLockedOut` uses a strict `>` against an instant read **once per response** from an injected `TimeProvider`.

That isn't ceremony. C1 requires `lockoutUntilUtc` *exactly equal* to the comparison instant to report `false`. With `DateTime.UtcNow` read inside the mapper that case cannot be arranged at all — a test can only get *slightly before*, where `>` and `>=` both return false, so **the test would pass with the predicate wrong**. Injecting the clock is what makes C1 a real assertion; a probe confirms that reverting to `DateTime.UtcNow` inside the mapper fails a test.

The instant is deferred behind a `Lazy<DateTime>`, so an empty page and a missing user never read the clock at all — which is what makes C2's and C4's *"no lockout computation is attempted"* demonstrable rather than assumed. Two tests use a `TimeProvider` that **throws when touched**.

`TimeProvider` is an optional constructor parameter falling back to `TimeProvider.System`, deliberately: this service is registered from `Authentication.DomainService`'s `RegisterAllServices` — the root `Api/Program.cs` actually calls — not from `Iam.DomainService`'s `RegisterSharedServices`, which only its own unit tests use. A required dependency registered in the wrong root would have failed when the API built the controller, invisibly to every unit test.

## Scope boundaries held

`GET /me` (`MapToSingleAccountFields`) is untouched and its complete key set is pinned. The new keys are added **after** the existing cross-org early return, so an out-of-org caller still gets an empty dictionary and no lockout state leaks across organizations — asserted by a test, because the pre-existing cross-org test only checked for the absence of `OrganizationsRoles` and would have passed with the lockout fields leaking.

## Verification

- **Tests:** 2159 passed, 0 failed (baseline 2139, so **+20**). `dotnet build` 0 errors. The baseline was fully green, so there is no pre-existing-failure allowance — any red would be mine.
- **11 mutation probes, 11 killed**: `>` → `>=`; the null key omitted; the clock read inside the mapper instead of injected; an existing key renamed; the lockout keys leaking into the `GET /me` mapper; the field dropped from the projection DTO (compile error); the clock read eagerly for an empty page; the clock read for a missing user; the authz attribute removed from `GetUsers`; the default-path null-deref "fixed"; and a key removed from the `GET /me` mapper.
- **Wire contract:** one test serialises through `IOptions<JsonOptions>` resolved from a real `AddControllers()` registration, asserting `lockoutUntilUtc` is **present with a JSON null** for a never-locked user and an **ISO-8601 UTC string ending in `Z`** for a locked one. Every other assertion inspects a `Dictionary<string, object>` and would pass even if HTTP serialisation dropped the null key — and Phase 2 is built against the JSON.

Two plan reviews and two code reviews; no unresolved critical or major findings.

### Where the evidence stops

**C3 is asserted as attribute presence, not a live 401.** Both endpoints still carry `[ProtectedEndPoint("blocks-iam::iam::users")]`, checked by reflection — but that proves the attribute survived, not that an unauthorised caller receives the same status and body. That needs an HTTP boundary these tests don't have.

**The §7 E2E steps have not been run.** They require a live API, a seeded tenant with three specific users, and an admin bearer token — none of which exist in this environment, and standing them up would mean touching a deployed environment. The xUnit half of §9 is fully covered; the E2E half is outstanding.

**The wire test doesn't exercise Genesis's `ConfigureApi`.** It resolves stock MVC options (measured: `DefaultIgnoreCondition = Never`, camelCase, zero converters). If Genesis ever added a converter or a `DictionaryKeyPolicy`, only a hosted response test would catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
