### PR TITLE
fix(iam): stop archived roles and permissions leaking through three c…

### DIFF
--- a/server/Iam.DomainService/Resources/ResponseModel/ArchiveImpactResponse.cs
+++ b/server/Iam.DomainService/Resources/ResponseModel/ArchiveImpactResponse.cs
@@ -27,6 +27,14 @@ namespace Iam.DomainService.Resources
         /// </summary>
         public int AffectedUserCount { get; set; }
 
+        /// <summary>
+        /// True when this role or permission is one of the tenant's signup defaults, so archiving it
+        /// also changes what every new account receives. Reported separately from the user count
+        /// because it is a different population: not people who hold it now, but everyone who would
+        /// have been given it from here on. Tenant-wide, so it is unaffected by organization scope.
+        /// </summary>
+        public bool IsSignUpDefault { get; set; }
+
         /// <summary>True when no consent can make the archive proceed.</summary>
         public bool Blocked { get; set; }
 

--- a/server/Iam.DomainService/Resources/Services/IResourceRepository.cs
+++ b/server/Iam.DomainService/Resources/Services/IResourceRepository.cs
@@ -64,6 +64,12 @@ namespace Iam.DomainService.Resources
         /// <summary>Removes the resource from the organization's bucket in every user holding it directly.</summary>
         Task<bool> RemovePermissionFromAllUsersAsync(string resource, string organizationId);
 
+        /// <summary>Removes the slug from the tenant's signup default roles. Tenant-wide, not org-scoped.</summary>
+        Task<bool> RemoveRoleFromSignUpDefaultsAsync(string slug);
+
+        /// <summary>Removes the resource from the tenant's signup default permissions. Tenant-wide, not org-scoped.</summary>
+        Task<bool> RemovePermissionFromSignUpDefaultsAsync(string resource);
+
         /// <summary>DISTINCT users holding this role slug in any of the given organizations.</summary>
         Task<long> CountUsersWithRoleAsync(string slug, IEnumerable<string> organizationIds, bool activeOnly);
 

--- a/server/Iam.DomainService/Resources/Services/ResourceMutationService.cs
+++ b/server/Iam.DomainService/Resources/Services/ResourceMutationService.cs
@@ -304,6 +304,27 @@ namespace Iam.DomainService.Resources
                 };
             }
 
+            // Archiving is ArchivePermissionAsync's job alone. This endpoint used to accept it as a
+            // field, which made it a second, silent delete path: one that never refreshed the
+            // default organization's role counts and had no way to revoke the direct user grants.
+            // Refused rather than ignored so a caller aiming at the wrong endpoint is told, instead
+            // of getting a 200 for a delete that did not happen.
+            if (command.IsArchived)
+            {
+                _logger.LogInformation("Permission update end -- Archive Attempted Through Update");
+                return Failure("IsArchived", "Use_Delete_Endpoint_To_Archive_Permission");
+            }
+
+            // An archived permission is terminal. Editing one would resurrect it below --
+            // UpdateAllSamePermissionAsync writes IsArchived to every organization's copy, so a
+            // routine name change would revive the permission tenant-wide with all of its role
+            // bindings still attached, since the archive deliberately preserves Permission.Roles.
+            if (permission.IsArchived)
+            {
+                _logger.LogInformation("Permission update end -- Already Archived");
+                return Failure("archived", "Cannot_Update_Archived_Permission");
+            }
+
             permission.Name = command.Name;
             permission.Description = command.Description;
             permission.Type = command.Type;
@@ -311,8 +332,12 @@ namespace Iam.DomainService.Resources
             permission.LastUpdatedDate = DateTime.Now;
             permission.LastUpdatedBy = blocksContext?.UserId;
             permission.Tags = command.Tags;
-            permission.IsArchived = command.IsArchived;
-            permission.IsBuiltIn = command.IsBuiltIn;
+            // IsArchived and IsBuiltIn are deliberately NOT taken from the request. Both are
+            // lifecycle state rather than editable attributes, and both are non-nullable bools on
+            // the request, so a client that omits them sends `false` -- which used to un-archive
+            // the permission and strip its built-in flag on an unrelated edit. Clearing IsBuiltIn
+            // that way also defeated the root-tenant guard in ArchivePermissionAsync, letting any
+            // tenant edit a built-in permission and then archive it.
             permission.ResourceGroup = command.ResourceGroup;
             permission.DependentPermissions = command.DependentPermissions;
             permission.PermissionSeverity = command.PermissionSeverity;
@@ -327,14 +352,15 @@ namespace Iam.DomainService.Resources
 
             await _resourceRepository.UpdateAllSamePermissionAsync(permission);
 
-            var mutationAction = command.IsArchived
-                ? MutationEventType.Delete
-                : MutationEventType.Update;
-
+            // Always an update now. The delete variants of both events were only reachable through
+            // the archive-by-update path refused above, and the propagation "delete" they queued
+            // routed into DeletePermissionForAllOrg -- which skips the default organization on the
+            // assumption that ArchivePermissionAsync already handled it, something this method
+            // never did.
             await SendResourceMutationEventAsync(
                 new ResourceMutationEvent
                 {
-                    Action = mutationAction,
+                    Action = MutationEventType.Update,
                     ItemId = permission.ItemId,
                     Entity = ResourceEntity.Permission
                 }
@@ -348,7 +374,7 @@ namespace Iam.DomainService.Resources
                     {
                         Entity = "permission",
                         ItemId = permission.ItemId,
-                        Action = command.IsArchived ? "delete" : "update"
+                        Action = "update"
                     }
                 );
             }
@@ -420,6 +446,28 @@ namespace Iam.DomainService.Resources
 
                     return new BaseMutationResponse();
                 }
+            }
+
+            // Unconditional, unlike the scrub above: this pulls a dangling pointer out of
+            // configuration rather than revoking anyone's current access, so there is nothing for a
+            // human to consent to. It matters because DefaultPermissionsForNewUserOnSignUp is
+            // copied verbatim into User.Permissions for every account created afterwards, and that
+            // dictionary is exactly what AuthorizationClaimsResolver reads when minting claims --
+            // so a resource left here hands every new signup a working grant on an archived
+            // permission, while Signup Configuration goes on listing it as though it existed.
+            //
+            // Tenant-wide: TenantConfiguration is one document per tenant, so this covers every
+            // organization at once and needs no counterpart in DeletePermissionForAllOrg.
+            var signUpDefaultsCleaned = await _resourceRepository.RemovePermissionFromSignUpDefaultsAsync(
+                permission.Resource);
+
+            if (!signUpDefaultsCleaned)
+            {
+                _logger.LogWarning(
+                    "Permission archive aborted for '{Resource}': the signup-defaults cleanup was not acknowledged. The permission is left active so a retry can complete it, rather than archived while new signups still receive it.",
+                    permission.Resource);
+
+                return new BaseMutationResponse();
             }
 
             permission.IsArchived = true;
@@ -570,14 +618,26 @@ namespace Iam.DomainService.Resources
             var permissionsCleaned = await _resourceRepository.RemoveRoleFromAllPermissionsAsync(role.Slug, role.OrganizationId);
             var usersCleaned = await _resourceRepository.RemoveRoleFromAllUsersAsync(role.Slug, role.OrganizationId);
 
-            if (!permissionsCleaned || !usersCleaned)
+            // The signup defaults are the third reference, and the one that keeps acting after the
+            // archive: DefaultRolesForNewUserOnSignUp is copied verbatim onto every account created
+            // afterwards, with no archived check anywhere along that path. Left behind, an archived
+            // role goes on being written into User.Roles for every new signup -- and goes on being
+            // shown in Signup Configuration as though it still existed.
+            //
+            // Tenant-wide rather than per organization, because TenantConfiguration is a single
+            // document per tenant. Not gated on consent: this removes a dangling pointer from
+            // configuration, it does not revoke anyone's current access.
+            var signUpDefaultsCleaned = await _resourceRepository.RemoveRoleFromSignUpDefaultsAsync(role.Slug);
+
+            if (!permissionsCleaned || !usersCleaned || !signUpDefaultsCleaned)
             {
                 _logger.LogWarning(
-                    "Role archive aborted for '{Slug}' in organization '{OrganizationId}': reference cleanup was not acknowledged (permissions: {PermissionsCleaned}, users: {UsersCleaned}). The role is left active so a retry can complete it.",
+                    "Role archive aborted for '{Slug}' in organization '{OrganizationId}': reference cleanup was not acknowledged (permissions: {PermissionsCleaned}, users: {UsersCleaned}, signup defaults: {SignUpDefaultsCleaned}). The role is left active so a retry can complete it.",
                     role.Slug,
                     role.OrganizationId,
                     permissionsCleaned,
-                    usersCleaned);
+                    usersCleaned,
+                    signUpDefaultsCleaned);
 
                 return new BaseMutationResponse();
             }
@@ -1164,6 +1224,43 @@ namespace Iam.DomainService.Resources
                 return true;
             }
 
+            // Under consent the direct grants are scrubbed per organization too, so the
+            // "no user still holds an archived permission" invariant holds everywhere, not only in
+            // the organization the administrator was looking at.
+            //
+            // Deliberately OUTSIDE the archive loop below, and for the same reason the role-count
+            // refresh is: by the time this consumer runs, ArchivePermissionAsync's
+            // UpdateAllSamePermissionAsync has usually already flipped IsArchived on every copy --
+            // it filters on Resource with no organization clause -- so that loop's IsArchived skip
+            // fires for every copy. While this scrub sat inside it, it was unreachable in practice,
+            // and every non-default organization kept its direct grants after an archive the
+            // administrator had explicitly consented to. Those grants are what mint a token claim,
+            // so the permission went on working there indefinitely.
+            //
+            // Best-effort per organization: the archive has already committed, so an unacknowledged
+            // scrub is logged and the rest are still attempted. It can no longer hold back the
+            // copy's archive -- that write has usually happened already, so refusing here would
+            // protect nothing while skipping the remaining organizations.
+            if (confirmRevokeFromUsers)
+            {
+                foreach (var organizationId in permissions
+                    .Select(x => x.OrganizationId)
+                    .Where(x => !string.IsNullOrWhiteSpace(x) && x != DefaultOrganizationId)
+                    .Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var usersCleaned = await _resourceRepository.RemovePermissionFromAllUsersAsync(
+                        permission.Resource, organizationId);
+
+                    if (!usersCleaned)
+                    {
+                        _logger.LogWarning(
+                            "Permission archive propagation: the direct user-grant cleanup for '{Resource}' in organization '{OrganizationId}' was not acknowledged. Users there may still hold the archived permission and need manual review.",
+                            permission.Resource,
+                            organizationId);
+                    }
+                }
+            }
+
             var stale = 0;
             foreach (var orgPermission in permissions)
             {
@@ -1175,24 +1272,6 @@ namespace Iam.DomainService.Resources
                 if (orgPermission.IsArchived)
                 {
                     continue;
-                }
-
-                // Under consent the direct grants are scrubbed per organization too, so the
-                // "no user still holds an archived permission" invariant holds everywhere, not
-                // only in the organization the administrator was looking at.
-                if (confirmRevokeFromUsers)
-                {
-                    var usersCleaned = await _resourceRepository.RemovePermissionFromAllUsersAsync(
-                        orgPermission.Resource, orgPermission.OrganizationId);
-
-                    if (!usersCleaned)
-                    {
-                        _logger.LogWarning(
-                            "Permission archive propagation skipped '{Resource}' in organization '{OrganizationId}': the direct user-grant cleanup was not acknowledged. The copy is left active rather than archived with users still holding it.",
-                            orgPermission.Resource,
-                            orgPermission.OrganizationId);
-                        continue;
-                    }
                 }
 
                 orgPermission.IsArchived = true;

--- a/server/Iam.DomainService/Resources/Services/ResourceQueryService.cs
+++ b/server/Iam.DomainService/Resources/Services/ResourceQueryService.cs
@@ -209,8 +209,10 @@ namespace Iam.DomainService.Resources
                 };
             }
 
-            var isMultiOrgEnabled = MultiOrgMode.IsEnabled(
-                await _resourceRepository.GetTenantConfigurationAsync(), _logger);
+            // One read, two answers: the configuration document carries both the multi-org flag and
+            // the signup defaults, so the signup check below costs no extra query.
+            var tenantConfiguration = await _resourceRepository.GetTenantConfigurationAsync();
+            var isMultiOrgEnabled = MultiOrgMode.IsEnabled(tenantConfiguration, _logger);
 
             // Only copies the archive would actually reach: already-archived ones are skipped by the
             // propagation, so counting them here would overstate the blast radius and make the
@@ -241,6 +243,8 @@ namespace Iam.DomainService.Resources
                 OrganizationCount = otherOrgIds.Count,
                 AffectedUserCount = (int)await _resourceRepository.CountUsersWithRoleAsync(role.Slug, userScopeOrgIds, activeOnly: false),
                 ActiveUserCount = (int)await _resourceRepository.CountUsersWithRoleAsync(role.Slug, userScopeOrgIds, activeOnly: true),
+                IsSignUpDefault = tenantConfiguration?.DefaultRolesForNewUserOnSignUp?
+                    .Any(x => string.Equals(x, role.Slug, StringComparison.OrdinalIgnoreCase)) ?? false,
                 Blocked = hasChildRoles,
                 BlockingReason = hasChildRoles ? "Role_Has_Child_Roles" : null
             };
@@ -261,8 +265,9 @@ namespace Iam.DomainService.Resources
                 };
             }
 
-            var isMultiOrgEnabled = MultiOrgMode.IsEnabled(
-                await _resourceRepository.GetTenantConfigurationAsync(), _logger);
+            // One read, two answers -- see GetRoleArchiveImpactAsync.
+            var tenantConfiguration = await _resourceRepository.GetTenantConfigurationAsync();
+            var isMultiOrgEnabled = MultiOrgMode.IsEnabled(tenantConfiguration, _logger);
 
             // Unlike Role, IsArchived has always existed on Permission and is present on every
             // document, so filtering it in memory here is safe.
@@ -291,6 +296,8 @@ namespace Iam.DomainService.Resources
                 // claim -- and the role bindings are separate populations and are reported apart.
                 AffectedUserCount = (int)await _resourceRepository.CountUsersWithPermissionAsync(permission.Resource, scopeOrgIds),
                 RoleBindingCount = (int)await _resourceRepository.CountRoleBindingsForResourceAsync(permission.Resource, scopeOrgIds),
+                IsSignUpDefault = tenantConfiguration?.DefaultPermissionsForNewUserOnSignUp?
+                    .Any(x => string.Equals(x, permission.Resource, StringComparison.OrdinalIgnoreCase)) ?? false,
                 // Permissions have no dependency that can hard-block an archive. Kept on the
                 // envelope so both dialogs render from one shape.
                 Blocked = false,

--- a/server/Iam.DomainService/Resources/Services/ResourceRepository.cs
+++ b/server/Iam.DomainService/Resources/Services/ResourceRepository.cs
@@ -395,6 +395,62 @@ namespace Iam.DomainService.Resources
         }
 
         /// <summary>
+        /// Removes a role slug from the tenant's signup defaults.
+        /// </summary>
+        /// <remarks>
+        /// TenantConfiguration is one document per tenant -- addressed by Filter.Empty, the same way
+        /// SaveSignUpSettingAsync and SaveOrganizationConfig address it -- so there is no
+        /// organization dimension here and one pull covers the whole tenant.
+        ///
+        /// This is not cosmetic cleanup of a stale list. DefaultRolesForNewUserOnSignUp is copied
+        /// verbatim onto every account created afterwards (AccountService, OidcCallbackHandler and
+        /// the user-creation consumer all read it, none of them filtering archived), so a slug left
+        /// here keeps being written into User.Roles for new users indefinitely.
+        ///
+        /// Exact match, like RemoveRoleFromAllUsersAsync: slugs are lower-cased when the role is
+        /// created and the signup list stores that same canonical value.
+        /// </remarks>
+        public async Task<bool> RemoveRoleFromSignUpDefaultsAsync(string slug)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return true;
+            }
+
+            var collection = _identityAccessManagementRepository.GetCollection<TenantConfiguration>();
+            var update = Builders<TenantConfiguration>.Update.Pull(t => t.DefaultRolesForNewUserOnSignUp, slug);
+            var result = await collection.UpdateOneAsync(Builders<TenantConfiguration>.Filter.Empty, update);
+
+            // IsAcknowledged, not ModifiedCount > 0: a role that was never a signup default -- or a
+            // tenant with no configuration document at all -- matches nothing, which is an
+            // acknowledged write of zero documents and a perfectly normal archive.
+            return result?.IsAcknowledged ?? false;
+        }
+
+        /// <summary>
+        /// Removes a permission resource from the tenant's signup defaults.
+        /// </summary>
+        /// <remarks>
+        /// The permission-side twin of <see cref="RemoveRoleFromSignUpDefaultsAsync"/>, and the more
+        /// consequential of the two: DefaultPermissionsForNewUserOnSignUp lands in
+        /// User.Permissions, which AuthorizationClaimsResolver reads directly when minting claims.
+        /// A resource left here grants every new account an archived permission that still works.
+        /// </remarks>
+        public async Task<bool> RemovePermissionFromSignUpDefaultsAsync(string resource)
+        {
+            if (string.IsNullOrWhiteSpace(resource))
+            {
+                return true;
+            }
+
+            var collection = _identityAccessManagementRepository.GetCollection<TenantConfiguration>();
+            var update = Builders<TenantConfiguration>.Update.Pull(t => t.DefaultPermissionsForNewUserOnSignUp, resource);
+            var result = await collection.UpdateOneAsync(Builders<TenantConfiguration>.Filter.Empty, update);
+
+            return result?.IsAcknowledged ?? false;
+        }
+
+        /// <summary>
         /// Counts DISTINCT users holding this role slug in ANY of the given organizations.
         /// </summary>
         /// <remarks>

--- a/server/XUnitTest/IamTests/Resources/ResourceMutationServiceTests.cs
+++ b/server/XUnitTest/IamTests/Resources/ResourceMutationServiceTests.cs
@@ -45,6 +45,8 @@ namespace XUnitTest.IamTests.Resources
             _repo.Setup(r => r.RemoveRoleFromAllPermissionsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
             _repo.Setup(r => r.RemoveRoleFromAllUsersAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
             _repo.Setup(r => r.RemovePermissionFromAllUsersAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+            _repo.Setup(r => r.RemoveRoleFromSignUpDefaultsAsync(It.IsAny<string>())).ReturnsAsync(true);
+            _repo.Setup(r => r.RemovePermissionFromSignUpDefaultsAsync(It.IsAny<string>())).ReturnsAsync(true);
             _repo.Setup(r => r.UpdateAllSamePermissionAsync(It.IsAny<Permission>())).ReturnsAsync(true);
             _iam.Setup(i => i.SendToQueueAsync(It.IsAny<string>(), It.IsAny<object>())).Returns(Task.CompletedTask);
             _activity.Setup(a => a.SendUserActivityAsync(It.IsAny<UserActivityEvent>())).Returns(Task.CompletedTask);
@@ -206,13 +208,64 @@ namespace XUnitTest.IamTests.Resources
         }
 
         [Fact]
-        public async Task UpdatePermission_Archived_SendsDeleteEvent()
+        public async Task UpdatePermission_ArchiveRequested_IsRefusedAndWritesNothing()
+        {
+            _repo.Setup(r => r.GetPermissionByIdAsync("p1")).ReturnsAsync(new Permission { ItemId = "p1", Name = "old", Resource = "old" });
+
+            var result = await Create().UpdatePermissionAsync("p1", new UpdatePermissionRequest { Name = "n", Resource = "r", ResourceGroup = "g", IsArchived = true });
+
+            // Archiving belongs to the delete endpoint alone. Refused rather than ignored so a
+            // caller aiming here is told, instead of getting a 200 for a delete that never ran.
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().ContainKey("IsArchived");
+            _repo.Verify(r => r.UpdatePermissionAsync(It.IsAny<Permission>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdatePermission_ArchivedPermission_CannotBeEdited()
+        {
+            _repo.Setup(r => r.GetPermissionByIdAsync("p1"))
+                .ReturnsAsync(new Permission { ItemId = "p1", Name = "old", Resource = "old", IsArchived = true });
+
+            var result = await Create().UpdatePermissionAsync("p1", new UpdatePermissionRequest { Name = "n", Resource = "r", ResourceGroup = "g" });
+
+            // Editing one used to resurrect it: UpdateAllSamePermissionAsync writes IsArchived to
+            // every organization's copy, so a name change revived it tenant-wide with its role
+            // bindings intact.
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().ContainKey("archived");
+            _repo.Verify(r => r.UpdatePermissionAsync(It.IsAny<Permission>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdatePermission_LeavesLifecycleFlagsAlone()
+        {
+            _repo.Setup(r => r.GetPermissionByIdAsync("p1"))
+                .ReturnsAsync(new Permission { ItemId = "p1", Name = "old", Resource = "old", IsBuiltIn = true });
+
+            // Both flags are non-nullable bools on the request, so this is also what a client that
+            // omits them sends. Applying them used to strip IsBuiltIn on an unrelated edit, which
+            // defeated the root-tenant guard in ArchivePermissionAsync.
+            var result = await Create().UpdatePermissionAsync("p1", new UpdatePermissionRequest { Name = "n", Resource = "r", ResourceGroup = "g", IsBuiltIn = false });
+
+            result.IsSuccess.Should().BeTrue();
+            _repo.Verify(r => r.UpdatePermissionAsync(It.Is<Permission>(p => p.IsBuiltIn && !p.IsArchived)), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdatePermission_PropagatesAsUpdateNeverAsDelete()
         {
             _repo.Setup(r => r.GetPermissionByIdAsync("p1")).ReturnsAsync(new Permission { ItemId = "p1", Name = "old", Resource = "old" });
             _repo.Setup(r => r.GetTenantConfigurationAsync()).ReturnsAsync(new TenantConfiguration { IsMultiOrgEnabled = true });
-            var result = await Create().UpdatePermissionAsync("p1", new UpdatePermissionRequest { Name = "n", Resource = "r", ResourceGroup = "g", IsArchived = true });
+
+            var result = await Create().UpdatePermissionAsync("p1", new UpdatePermissionRequest { Name = "n", Resource = "r", ResourceGroup = "g" });
+
             result.IsSuccess.Should().BeTrue();
-            _iam.Verify(i => i.SendToQueueAsync(It.IsAny<string>(), It.Is<PropagationRolePermissionUpdateEvent>(e => e.Action == "delete")), Times.Once);
+            // The "delete" action routed into DeletePermissionForAllOrg, which skips the default
+            // organization on the assumption the archive already handled it -- something this
+            // method never did, leaving the default organization's role counts stale.
+            _iam.Verify(i => i.SendToQueueAsync(It.IsAny<string>(), It.Is<PropagationRolePermissionUpdateEvent>(e => e.Action == "update")), Times.Once);
+            _iam.Verify(i => i.SendToQueueAsync(It.IsAny<string>(), It.Is<PropagationRolePermissionUpdateEvent>(e => e.Action == "delete")), Times.Never);
         }
 
         [Fact]
@@ -1099,6 +1152,36 @@ namespace XUnitTest.IamTests.Resources
         }
 
         [Fact]
+        public async Task ArchiveRole_RemovesTheSlugFromTheSignUpDefaults()
+        {
+            InstallContext(orgId: "acme");
+            GivenRole(ArchiveRoleTarget(org: "acme"));
+
+            var result = await Create().ArchiveRoleAsync("r1");
+
+            result.IsSuccess.Should().BeTrue();
+            // DefaultRolesForNewUserOnSignUp is copied verbatim onto every account created after
+            // this point, with no archived check on that path -- so a slug left here keeps being
+            // written into User.Roles for new signups. Tenant-wide, hence no organization argument.
+            _repo.Verify(r => r.RemoveRoleFromSignUpDefaultsAsync("manager"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ArchiveRole_SignUpDefaultsCleanupUnacknowledged_LeavesRoleActive()
+        {
+            InstallContext(orgId: "acme");
+            GivenRole(ArchiveRoleTarget(org: "acme"));
+            _repo.Setup(r => r.RemoveRoleFromSignUpDefaultsAsync(It.IsAny<string>())).ReturnsAsync(false);
+
+            var result = await Create().ArchiveRoleAsync("r1");
+
+            // Same reasoning as the other reference cleanups: an archived role still being handed to
+            // every new signup is the worse half-state, so the archive waits for a retry.
+            result.IsSuccess.Should().BeFalse();
+            _repo.Verify(r => r.UpdateRoleAsync(It.IsAny<Role>()), Times.Never);
+        }
+
+        [Fact]
         public async Task ArchiveRole_DefaultOrgMasterRole_Succeeds()
         {
             GivenRole(ArchiveRoleTarget());
@@ -1478,6 +1561,35 @@ namespace XUnitTest.IamTests.Resources
         }
 
         [Fact]
+        public async Task ArchivePermission_RemovesTheResourceFromTheSignUpDefaults_WithoutConsent()
+        {
+            InstallContext(orgId: "default");
+            GivenPermission(ArchiveTarget());
+
+            var result = await Create().ArchivePermissionAsync("p1");
+
+            result.IsSuccess.Should().BeTrue();
+            // Deliberately NOT consent-gated: this pulls a dangling pointer out of configuration
+            // rather than revoking anyone's access. Left behind, it would keep handing every new
+            // signup a working grant on an archived permission, since
+            // DefaultPermissionsForNewUserOnSignUp lands in User.Permissions.
+            _repo.Verify(r => r.RemovePermissionFromSignUpDefaultsAsync("reports::export"), Times.Once);
+        }
+
+        [Fact]
+        public async Task ArchivePermission_SignUpDefaultsCleanupUnacknowledged_LeavesPermissionActive()
+        {
+            InstallContext(orgId: "default");
+            GivenPermission(ArchiveTarget());
+            _repo.Setup(r => r.RemovePermissionFromSignUpDefaultsAsync(It.IsAny<string>())).ReturnsAsync(false);
+
+            var result = await Create().ArchivePermissionAsync("p1");
+
+            result.IsSuccess.Should().BeFalse();
+            _repo.Verify(r => r.UpdatePermissionAsync(It.IsAny<Permission>()), Times.Never);
+        }
+
+        [Fact]
         public async Task ArchivePermission_WithConsent_UserCleanupUnacknowledged_LeavesPermissionActive()
         {
             InstallContext(orgId: "default");
@@ -1518,6 +1630,91 @@ namespace XUnitTest.IamTests.Resources
             _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "globex"), Times.Once);
             // The default-organization record is handled by ArchivePermissionAsync, never here.
             _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "default"), Times.Never);
+        }
+
+        [Fact]
+        public async Task PropagatePermissionDelete_WithConsent_CopiesAlreadyArchived_StillScrubsDirectGrants()
+        {
+            GivenPermission(ArchiveTarget());
+            // The state production actually reaches: ArchivePermissionAsync calls
+            // UpdateAllSamePermissionAsync, an UpdateMany filtered on Resource with no organization
+            // clause, so every copy is already archived before this consumer runs. While the scrub
+            // sat inside the archive loop it was skipped for all of them, and the direct grants --
+            // the binding that mints a token claim -- survived the archive in every organization.
+            _repo.Setup(r => r.GetPermissionsByResourceAsync("reports::export")).ReturnsAsync(new List<Permission>
+            {
+                ArchiveTarget(),
+                new() { ItemId = "p-acme", Resource = "reports::export", OrganizationId = "acme", IsArchived = true },
+                new() { ItemId = "p-globex", Resource = "reports::export", OrganizationId = "globex", IsArchived = true }
+            });
+
+            await Create().ExecutePropagationRolePermissionUpdateAsync(
+                new PropagationRolePermissionUpdateEvent
+                {
+                    Entity = "permission",
+                    Action = "delete",
+                    ItemId = "p1",
+                    ConfirmRevokeFromUsers = true
+                });
+
+            _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "acme"), Times.Once);
+            _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "globex"), Times.Once);
+            _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "default"), Times.Never);
+            // Nothing left to archive, and the scrub still had to run.
+            _repo.Verify(r => r.UpdatePermissionsAsync(It.IsAny<List<Permission>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task PropagatePermissionDelete_WithConsent_UnacknowledgedScrub_StillScrubsTheRest()
+        {
+            GivenPermission(ArchiveTarget());
+            _repo.Setup(r => r.GetPermissionsByResourceAsync("reports::export")).ReturnsAsync(new List<Permission>
+            {
+                ArchiveTarget(),
+                new() { ItemId = "p-acme", Resource = "reports::export", OrganizationId = "acme" },
+                new() { ItemId = "p-globex", Resource = "reports::export", OrganizationId = "globex" }
+            });
+            _repo.Setup(r => r.UpdatePermissionsAsync(It.IsAny<List<Permission>>())).ReturnsAsync(true);
+            _repo.Setup(r => r.RemovePermissionFromAllUsersAsync("reports::export", "acme")).ReturnsAsync(false);
+
+            await Create().ExecutePropagationRolePermissionUpdateAsync(
+                new PropagationRolePermissionUpdateEvent
+                {
+                    Entity = "permission",
+                    Action = "delete",
+                    ItemId = "p1",
+                    ConfirmRevokeFromUsers = true
+                });
+
+            // Best-effort per organization: the archive has already committed, so one unacknowledged
+            // scrub is logged and must not stop the others being cleaned.
+            _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "globex"), Times.Once);
+        }
+
+        [Fact]
+        public async Task PropagatePermissionDelete_WithConsent_DuplicateOrgCopies_ScrubbedOnce()
+        {
+            GivenPermission(ArchiveTarget());
+            _repo.Setup(r => r.GetPermissionsByResourceAsync("reports::export")).ReturnsAsync(new List<Permission>
+            {
+                ArchiveTarget(),
+                new() { ItemId = "p-acme", Resource = "reports::export", OrganizationId = "acme" },
+                new() { ItemId = "p-acme-dup", Resource = "reports::export", OrganizationId = "acme" }
+            });
+            _repo.Setup(r => r.UpdatePermissionsAsync(It.IsAny<List<Permission>>())).ReturnsAsync(true);
+
+            await Create().ExecutePropagationRolePermissionUpdateAsync(
+                new PropagationRolePermissionUpdateEvent
+                {
+                    Entity = "permission",
+                    Action = "delete",
+                    ItemId = "p1",
+                    ConfirmRevokeFromUsers = true
+                });
+
+            // One organization's grants are pulled by resource, so a second copy from data drift is
+            // wasted work rather than a wrong answer.
+            _repo.Verify(r => r.RemovePermissionFromAllUsersAsync("reports::export", "acme"), Times.Once);
         }
 
         [Fact]

--- a/server/XUnitTest/IamTests/Resources/ResourceQueryServiceTests.cs
+++ b/server/XUnitTest/IamTests/Resources/ResourceQueryServiceTests.cs
@@ -399,6 +399,50 @@ namespace XUnitTest.IamTests.Resources
         }
 
         [Fact]
+        public async Task RoleArchiveImpact_ReportsWhetherTheRoleIsASignUpDefault()
+        {
+            _repo.Setup(r => r.GetRoleByIdAsync("r1")).ReturnsAsync(ImpactRole());
+            _repo.Setup(r => r.GetTenantConfigurationAsync()).ReturnsAsync(new TenantConfiguration
+            {
+                DefaultRolesForNewUserOnSignUp = new List<string> { "viewer", "MANAGER" }
+            });
+
+            var result = await Create().GetRoleArchiveImpactAsync("r1");
+
+            // Case-insensitive: the signup list is stored as the client sent it and is not
+            // normalised on save, unlike the slug on the role itself.
+            result.IsSignUpDefault.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task RoleArchiveImpact_NotASignUpDefault_ReportsFalse()
+        {
+            _repo.Setup(r => r.GetRoleByIdAsync("r1")).ReturnsAsync(ImpactRole());
+            _repo.Setup(r => r.GetTenantConfigurationAsync()).ReturnsAsync(new TenantConfiguration
+            {
+                DefaultRolesForNewUserOnSignUp = new List<string> { "viewer" },
+                // The permission list must never answer the role question.
+                DefaultPermissionsForNewUserOnSignUp = new List<string> { "manager" }
+            });
+
+            var result = await Create().GetRoleArchiveImpactAsync("r1");
+
+            result.IsSignUpDefault.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task RoleArchiveImpact_NoTenantConfiguration_ReportsNotASignUpDefault()
+        {
+            _repo.Setup(r => r.GetRoleByIdAsync("r1")).ReturnsAsync(ImpactRole());
+            MultiOrg(false);
+
+            var result = await Create().GetRoleArchiveImpactAsync("r1");
+
+            // A null configuration document must read as "not a default" rather than throwing.
+            result.IsSignUpDefault.Should().BeFalse();
+        }
+
+        [Fact]
         public async Task RoleArchiveImpact_ArchivedCopyWidensNeitherCount()
         {
             IEnumerable<string>? scoped = null;
@@ -509,6 +553,35 @@ namespace XUnitTest.IamTests.Resources
             result.RoleBindingCount.Should().Be(3);
             result.Blocked.Should().BeFalse();
             result.BlockingReason.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task PermissionArchiveImpact_ReportsWhetherThePermissionIsASignUpDefault()
+        {
+            var permission = new Permission { ItemId = "p1", Name = "Export", Resource = "reports::export", OrganizationId = "default" };
+            _repo.Setup(r => r.GetPermissionByIdAsync("p1")).ReturnsAsync(permission);
+            _repo.Setup(r => r.GetTenantConfigurationAsync()).ReturnsAsync(new TenantConfiguration
+            {
+                DefaultPermissionsForNewUserOnSignUp = new List<string> { "reports::export" },
+                // The role list must never answer the permission question.
+                DefaultRolesForNewUserOnSignUp = new List<string> { "manager" }
+            });
+
+            var result = await Create().GetPermissionArchiveImpactAsync("p1");
+
+            result.IsSignUpDefault.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task PermissionArchiveImpact_NotASignUpDefault_ReportsFalse()
+        {
+            var permission = new Permission { ItemId = "p1", Name = "Export", Resource = "reports::export", OrganizationId = "default" };
+            _repo.Setup(r => r.GetPermissionByIdAsync("p1")).ReturnsAsync(permission);
+            MultiOrg(false);
+
+            var result = await Create().GetPermissionArchiveImpactAsync("p1");
+
+            result.IsSignUpDefault.Should().BeFalse();
         }
 
         [Fact]

--- a/server/XUnitTest/IamTests/Resources/ResourceRepositoryTests.cs
+++ b/server/XUnitTest/IamTests/Resources/ResourceRepositoryTests.cs
@@ -896,6 +896,71 @@ namespace XUnitTest.IamTests.Resources
             (await Sut().RemovePermissionFromAllUsersAsync(resource, org)).Should().BeTrue();
         }
 
+        // ---------- Signup-default scrub ----------
+
+        [Fact]
+        public async Task RemoveRoleFromSignUpDefaultsAsync_PullsTheSlugFromTheRolesListOnly()
+        {
+            UpdateDefinition<TenantConfiguration>? capturedUpdate = null;
+            var col = Register<TenantConfiguration>();
+            col.Setup(c => c.UpdateOneAsync(It.IsAny<FilterDefinition<TenantConfiguration>>(), It.IsAny<UpdateDefinition<TenantConfiguration>>(), It.IsAny<UpdateOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<FilterDefinition<TenantConfiguration>, UpdateDefinition<TenantConfiguration>, UpdateOptions, CancellationToken>((_, u, _, _) => capturedUpdate = u)
+                .ReturnsAsync(new UpdateResult.Acknowledged(1, 1, null));
+
+            (await Sut().RemoveRoleFromSignUpDefaultsAsync("manager")).Should().BeTrue();
+
+            var registry = BsonSerializer.SerializerRegistry;
+            var update = capturedUpdate!.Render(new RenderArgs<TenantConfiguration>(registry.GetSerializer<TenantConfiguration>(), registry)).ToString();
+
+            // The roles list, not the permissions list: they are separate signup defaults and a
+            // slug must never be pulled from the one that holds permission resources.
+            update.Should().Contain("DefaultRolesForNewUserOnSignUp").And.Contain("manager");
+            update.Should().NotContain("DefaultPermissionsForNewUserOnSignUp");
+        }
+
+        [Fact]
+        public async Task RemovePermissionFromSignUpDefaultsAsync_PullsTheResourceFromThePermissionsListOnly()
+        {
+            UpdateDefinition<TenantConfiguration>? capturedUpdate = null;
+            var col = Register<TenantConfiguration>();
+            col.Setup(c => c.UpdateOneAsync(It.IsAny<FilterDefinition<TenantConfiguration>>(), It.IsAny<UpdateDefinition<TenantConfiguration>>(), It.IsAny<UpdateOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<FilterDefinition<TenantConfiguration>, UpdateDefinition<TenantConfiguration>, UpdateOptions, CancellationToken>((_, u, _, _) => capturedUpdate = u)
+                .ReturnsAsync(new UpdateResult.Acknowledged(1, 1, null));
+
+            (await Sut().RemovePermissionFromSignUpDefaultsAsync("reports::export")).Should().BeTrue();
+
+            var registry = BsonSerializer.SerializerRegistry;
+            var update = capturedUpdate!.Render(new RenderArgs<TenantConfiguration>(registry.GetSerializer<TenantConfiguration>(), registry)).ToString();
+
+            update.Should().Contain("DefaultPermissionsForNewUserOnSignUp").And.Contain("reports::export");
+            update.Should().NotContain("DefaultRolesForNewUserOnSignUp");
+        }
+
+        [Fact]
+        public async Task RemoveFromSignUpDefaultsAsync_MatchingNothingIsSuccessNotFailure()
+        {
+            var col = Register<TenantConfiguration>();
+            col.Setup(c => c.UpdateOneAsync(It.IsAny<FilterDefinition<TenantConfiguration>>(), It.IsAny<UpdateDefinition<TenantConfiguration>>(), It.IsAny<UpdateOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateResult.Acknowledged(0, 0, null));
+
+            // A role that was never a signup default -- or a tenant with no configuration document
+            // at all -- matches nothing. Treating that as a failure would abort every archive in
+            // any tenant that has never opened Signup Configuration.
+            (await Sut().RemoveRoleFromSignUpDefaultsAsync("manager")).Should().BeTrue();
+            (await Sut().RemovePermissionFromSignUpDefaultsAsync("reports::export")).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task RemoveFromSignUpDefaultsAsync_IgnoresBlankArguments(string value)
+        {
+            Register<TenantConfiguration>();
+
+            (await Sut().RemoveRoleFromSignUpDefaultsAsync(value)).Should().BeTrue();
+            (await Sut().RemovePermissionFromSignUpDefaultsAsync(value)).Should().BeTrue();
+        }
+
         // ---------- Archive impact counting (#464) ----------
 
         [Fact]


### PR DESCRIPTION
…leanup gaps

Archiving a role or permission left three references behind, each of which kept granting access or misreporting state after the delete.

1. POST /permissions/{id} was a second, silent delete path. IsArchived and IsBuiltIn were read straight off the request, and both are non-nullable bools -- so a client that omits them (both clients do) sent `false`, un-archiving the permission and stripping its built-in flag on any unrelated edit. UpdateAllSamePermissionAsync then revived every organization's copy with its role bindings intact, since the archive deliberately preserves Permission.Roles. Clearing IsBuiltIn also defeated the root-tenant guard in ArchivePermissionAsync: edit the flag away, then archive.

   Neither flag is read from the request now. An explicit isArchived:true is refused (Use_Delete_Endpoint_To_Archive_Permission) rather than ignored, so a caller aiming at the wrong endpoint is told instead of getting a 200 for a delete that never ran, and editing an already-archived permission is refused outright. The delete variants of both events are gone -- this path always propagates as "update". The "delete" it used to queue routed into DeletePermissionForAllOrg, which skips the default organization on the assumption the archive already refreshed its role counts, something this method never did.

2. The multi-org consent scrub was unreachable. ArchivePermissionAsync calls UpdateAllSamePermissionAsync -- an UpdateMany filtered on Resource with no organization clause -- before queueing propagation, so every copy is already archived by the time DeletePermissionForAllOrg runs and its `if (IsArchived) continue;` fires for all of them. The direct user-grant scrub sat behind that skip, so User.Permissions kept its entry in every non-default organization even when an administrator had explicitly consented to the revocation. That dictionary is what mints a token claim, so the permission went on working there indefinitely. Hoisted out of the loop -- exactly where the role-count refresh already sits, for the same reason -- and made best-effort per organization.

3. Signup defaults were never cleaned. DefaultRolesForNewUserOnSignUp and DefaultPermissionsForNewUserOnSignUp are copied verbatim onto every account created afterwards (AccountService, OidcCallbackHandler and the user-creation consumer all read them, none filtering archived), so a deleted role kept being written into User.Roles for new signups and a deleted permission kept handing them a working grant through User.Permissions. Both archives now pull their entry from the tenant configuration, and the archive-impact preview reports IsSignUpDefault so the confirm dialog can say so.

The signup scrub is unconditional rather than consent-gated: it removes a dangling pointer from configuration, not anyone's current access. Like the other reference cleanups it precedes the archive write, so an unacknowledged scrub leaves the target active for a retry instead of archiving it while new signups still receive it.