### PR TITLE
Derive IAM's own API base URL from the serving origin

### DIFF
--- a/client/app/idp/mfa/services/mfa.service.test.ts
+++ b/client/app/idp/mfa/services/mfa.service.test.ts
@@ -21,6 +21,10 @@ import {
 
 vi.mock("@/lib/http-client", () => mockHttpClientFactory());
 
+// The service prefixes its absolute-URL calls with the serving origin
+// (getSelfBaseUrl), which under jsdom is the test document's origin.
+const iamUrl = (path: string) => `${window.location.origin}${path}`;
+
 describe("MFAService", () => {
   let service: MFAService;
 
@@ -40,7 +44,7 @@ describe("MFAService", () => {
 
       const result = await service.getConfigurations();
 
-      expect(http.get).toHaveBeenCalledWith(MFA_CONFIG_ENDPOINTS.GET, undefined, {
+      expect(http.get).toHaveBeenCalledWith(iamUrl(MFA_CONFIG_ENDPOINTS.GET), undefined, {
         absoluteUrl: true,
       });
       expect(result).toEqual(mockMfaConfigResponse);
@@ -61,7 +65,7 @@ describe("MFAService", () => {
       const result = await service.saveMFAConfiguration(mockSaveMfaConfigPayload);
 
       expect(http.post).toHaveBeenCalledWith(
-        MFA_CONFIG_ENDPOINTS.SAVE,
+        iamUrl(MFA_CONFIG_ENDPOINTS.SAVE),
         mockSaveMfaConfigPayload,
         undefined,
         { absoluteUrl: true },
@@ -86,7 +90,7 @@ describe("MFAService", () => {
       const result = await service.generateUserMfaOTP(mockGenerateOtpPayload);
 
       expect(http.post).toHaveBeenCalledWith(
-        MFA_ENDPOINTS.GENERATE_OTP,
+        iamUrl(MFA_ENDPOINTS.GENERATE_OTP),
         mockGenerateOtpPayload,
         undefined,
         { absoluteUrl: true },
@@ -133,7 +137,7 @@ describe("MFAService", () => {
 
       const result = await service.setupUserTotp(mockSetupTotpPayload);
 
-      expect(http.post).toHaveBeenCalledWith(MFA_ENDPOINTS.SETUP_TOTP, {}, undefined, {
+      expect(http.post).toHaveBeenCalledWith(iamUrl(MFA_ENDPOINTS.SETUP_TOTP), {}, undefined, {
         absoluteUrl: true,
       });
       expect(result).toEqual(mockSetupTotpResponse);
@@ -153,7 +157,7 @@ describe("MFAService", () => {
 
       const result = await service.verifyOtp(mockVerifyOtpPayload);
 
-      expect(http.post).toHaveBeenCalledWith(MFA_ENDPOINTS.VERIFY_OTP, mockVerifyOtpPayload, undefined, {
+      expect(http.post).toHaveBeenCalledWith(iamUrl(MFA_ENDPOINTS.VERIFY_OTP), mockVerifyOtpPayload, undefined, {
         absoluteUrl: true,
       });
       expect(result).toEqual(mockVerifyOtpResponse);
@@ -192,7 +196,7 @@ describe("MFAService", () => {
       const result = await service.disableMFA(mockDisableMfaPayload);
 
       expect(http.post).toHaveBeenCalledWith(
-        MFA_ENDPOINTS.DISABLE_MFA,
+        iamUrl(MFA_ENDPOINTS.DISABLE_MFA),
         mockDisableMfaPayload,
         undefined,
         { absoluteUrl: true },

--- a/client/app/idp/mfa/services/mfa.service.ts
+++ b/client/app/idp/mfa/services/mfa.service.ts
@@ -1,7 +1,7 @@
 import { serviceInstances } from "@/lib/http-client";
-import { getRuntimeEnv } from "@/lib/runtime-env";
+import { getSelfBaseUrl } from "@/lib/runtime-env";
 
-const toIamUrl = (path: string) => `${getRuntimeEnv("BLOCKS_IAM_BASE_URL")}${path}`;
+const toIamUrl = (path: string) => `${getSelfBaseUrl()}${path}`;
 import {
   IGenerateUserMFA_OtpPayload,
   IGenerateUserMFA_OtpResponse,

--- a/client/app/lib/get-api-path.test.ts
+++ b/client/app/lib/get-api-path.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getRuntimeEnv } from "@/lib/runtime-env";
+import { getSelfBaseUrl } from "@/lib/runtime-env";
 import { getApiPath, getApiUrl } from "./get-api-path";
 
-vi.mock("@/lib/runtime-env", () => ({ getRuntimeEnv: vi.fn(() => "https://api.example.com") }));
+vi.mock("@/lib/runtime-env", () => ({ getSelfBaseUrl: vi.fn(() => "https://api.example.com") }));
 
 describe("get-api-path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getRuntimeEnv).mockReturnValue("https://api.example.com");
+    vi.mocked(getSelfBaseUrl).mockReturnValue("https://api.example.com");
   });
 
   describe("getApiPath", () => {
@@ -25,15 +25,15 @@ describe("get-api-path", () => {
       );
     });
 
-    it("should read the base URL from the runtime env", () => {
+    it("should read the base URL from the serving origin, not the injected config", () => {
       expect(getApiUrl("iam", "Authentication/Login")).toBe(
         "https://api.example.com/api/Authentication/Login",
       );
-      expect(getRuntimeEnv).toHaveBeenCalledWith("BLOCKS_IAM_BASE_URL");
+      expect(getSelfBaseUrl).toHaveBeenCalled();
     });
 
     it("should handle an empty base URL", () => {
-      vi.mocked(getRuntimeEnv).mockReturnValue("");
+      vi.mocked(getSelfBaseUrl).mockReturnValue("");
       expect(getApiUrl("iam", ".well-known/jwks.json")).toBe("/api/.well-known/jwks.json");
     });
   });

--- a/client/app/lib/get-api-path.ts
+++ b/client/app/lib/get-api-path.ts
@@ -1,4 +1,4 @@
-import { getRuntimeEnv } from "@/lib/runtime-env";
+import { getSelfBaseUrl } from "@/lib/runtime-env";
 
 /**
  * Returns the global API path prefix. All app API routes use `/api` (same in every environment).
@@ -14,7 +14,7 @@ export const getApiPath = (_servicePath: string): string => {
  * @param endpoint - The path after `/api` (e.g. `Authentication/Login`, `.well-known/jwks.json`)
  */
 export const getApiUrl = (_servicePath: string, endpoint: string): string => {
-  const baseUrl = getRuntimeEnv("BLOCKS_IAM_BASE_URL");
+  const baseUrl = getSelfBaseUrl();
   const apiPath = getApiPath(_servicePath);
   return `${baseUrl}${apiPath}/${endpoint}`;
 };

--- a/client/app/lib/http-client.ts
+++ b/client/app/lib/http-client.ts
@@ -1,4 +1,4 @@
-import { getRuntimeEnv } from "@/lib/runtime-env";
+import { getRuntimeEnv, getSelfBaseUrl } from "@/lib/runtime-env";
 import { HttpClient } from "@seliseblocks/genesis-os/lib";
 
 export const serviceInstances = {
@@ -7,7 +7,9 @@ export const serviceInstances = {
     blocksKey: getRuntimeEnv("BLOCKS_X_BLOCKS_KEY") || "",
   }),
   idpService: new HttpClient({
-    baseURL: getRuntimeEnv("BLOCKS_IAM_BASE_URL") || "",
+    // IAM's own API is same-origin with this SPA. Resolved per request rather
+    // than at module load, so nothing depends on script ordering.
+    baseURL: () => getSelfBaseUrl(),
     blocksKey: getRuntimeEnv("BLOCKS_X_BLOCKS_KEY") || "",
   }),
 };

--- a/client/app/lib/runtime-env.ts
+++ b/client/app/lib/runtime-env.ts
@@ -49,3 +49,17 @@ export const getRuntimeEnv = (key: RuntimeKey): string => {
 
   return import.meta.env[key] || "";
 };
+
+/**
+ * Base URL for calls to IAM's *own* API. The SPA is always served by the same
+ * host that serves `/api/*` (the client is built into `server/Api/wwwroot` and
+ * one Kestrel serves both), so the browser origin is authoritative.
+ *
+ * Prefer this over `getRuntimeEnv("BLOCKS_IAM_BASE_URL")` for self-calls:
+ * that value is baked into wwwroot at container start, when the app cannot yet
+ * know which host it will be served on, so it is wrong on any host other than
+ * the canonical one — notably per-PR preview environments. Cross-service URLs
+ * (BLOCKS_LOGIC_BASE_URL etc.) must still come from `getRuntimeEnv`.
+ */
+export const getSelfBaseUrl = (): string =>
+  typeof window !== "undefined" ? window.location.origin : "";

--- a/client/app/routes/auth/sso-callback.test.tsx
+++ b/client/app/routes/auth/sso-callback.test.tsx
@@ -2,12 +2,12 @@ import { render, waitFor } from "@testing-library/react";
 import { Routes, Route, MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const h = vi.hoisted(() => ({ setAuthenticated: vi.fn(), getRuntimeEnv: vi.fn() }));
+const h = vi.hoisted(() => ({ setAuthenticated: vi.fn(), getSelfBaseUrl: vi.fn() }));
 
 vi.mock("@seliseblocks/genesis-os", () => ({
   useAuthStore: () => ({ setAuthenticated: h.setAuthenticated }),
 }));
-vi.mock("@/lib/runtime-env", () => ({ getRuntimeEnv: h.getRuntimeEnv }));
+vi.mock("@/lib/runtime-env", () => ({ getSelfBaseUrl: h.getSelfBaseUrl }));
 vi.mock("@blocks-idp/authentication/utils/oidc-utils", () => ({
   getCurrentOIDCParams: () => new URLSearchParams(),
   OIDC_DEVICE_RETURN_URL_STORAGE_KEY: "oidc-device-return-url",
@@ -27,7 +27,7 @@ const renderAt = (entry: string) =>
 const originalLocation = window.location;
 beforeEach(() => {
   vi.clearAllMocks();
-  h.getRuntimeEnv.mockReturnValue("https://iam.example.com");
+  h.getSelfBaseUrl.mockReturnValue("https://iam.example.com");
   Object.defineProperty(window, "location", {
     configurable: true,
     writable: true,

--- a/client/app/routes/auth/sso-callback.tsx
+++ b/client/app/routes/auth/sso-callback.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { useAuthStore } from "@seliseblocks/genesis-os";
-import { getRuntimeEnv } from "@/lib/runtime-env";
+import { getSelfBaseUrl } from "@/lib/runtime-env";
 import { showErrorToast } from "@/hooks/use-toast";
 import {
   getCurrentOIDCParams,
@@ -24,10 +24,7 @@ export default function SSOCallbackPage() {
 
     hasProcessed.current = true;
 
-    const callbackUrl = new URL(
-      "/api/oidc/callback",
-      getRuntimeEnv("BLOCKS_IAM_BASE_URL"),
-    );
+    const callbackUrl = new URL("/api/oidc/callback", getSelfBaseUrl());
     if (code) callbackUrl.searchParams.set("code", code);
     if (state) callbackUrl.searchParams.set("state", state);
     if (tenantId) callbackUrl.searchParams.set("tenant_id", tenantId);


### PR DESCRIPTION
## Why

The IAM SPA is built into `server/Api/wwwroot` and served by the same Kestrel that serves `/api/*`, so **the browser origin is always the correct base URL for self-calls**.

`BLOCKS_IAM_BASE_URL` is baked into `wwwroot` at container start (`Program.cs:49`, before `builder.Build()`), when the app has no way to know which host it will be served on — `ASPNETCORE_URLS` is only a bind address. It is therefore wrong on any host other than the canonical one, which breaks per-PR preview environments: the preview's SPA calls shared dev instead of itself, so the PR's own backend is never exercised.

Injecting the value per deployment isn't currently possible either — the Mongo `Secrets` configuration provider is registered *after* `AddEnvironmentVariables()` (`Program.cs:24` vs `:9`), and .NET resolves last-provider-wins, so Mongo shadows env vars, Helm values and GitHub secrets alike. Deriving the base from the origin sidesteps that entirely.

## What changed

Adds `getSelfBaseUrl()` to `client/app/lib/runtime-env.ts` and uses it for the four self-call paths:

| File | Covers |
|---|---|
| `app/lib/http-client.ts` — `idpService` | ~190 call sites across ~28 service files (all pass relative `/api/...`) |
| `app/lib/get-api-path.ts` — `getApiUrl` | 1 site |
| `app/idp/mfa/services/mfa.service.ts` — `toIamUrl` | 7 sites |
| `app/routes/auth/sso-callback.tsx` | 1 site |

`idpService.baseURL` is passed as a thunk (`HttpClientConfig.baseURL` accepts `string | (() => string)`), so it resolves per request and nothing depends on module-load ordering.

## What deliberately did *not* change

`BLOCKS_IAM_BASE_URL` stays in the DB, in `index.html`, and in the `RuntimeKey` union — the other nine apps consume it as a cross-origin pointer, and the backend reads it as an issuer fallback (`OidcServices.cs:526-528`).

Also untouched:
- `logicService` → `BLOCKS_LOGIC_BASE_URL` (genuinely a different origin)
- the two `.includes("localhost")` gates (`routes/oidc/index.tsx`, `sso-activate.tsx`) — these drive token storage and `credentials` mode; worth a separate deliberate change to `window.location.hostname`
- `sso-signin-card.tsx`'s `provider_redirect_uri` — must match what's registered at the third-party provider
- the swagger link in `service-card.tsx`
- `vite.config.ts`'s dev-proxy target

## Impact

For **dev/stg/prod the resolved value is byte-identical to today**, because those hosts already match the configured URL. Preview environments are the only place the value differs — which is the point.

| Environment | Serves SPA at | Config says | Origin | Result |
|---|---|---|---|---|
| prod / stg / dev | canonical host | same | same | no change |
| preview | `dev-iam-<pr>…` | `dev-iam…` ❌ | `dev-iam-<pr>…` ✅ | fixed |

## Testing

- `npm run type-check` — clean
- `npm test` — **1478 passed / 204 files**, no failures
- `npm run build` — succeeds

Test updates were confined to the three suites that asserted on the old prefix; assertions now derive the expected origin rather than hardcoding it.

## Reviewer note — one behaviour change to be aware of

Under `npm run dev`, self-calls previously went **direct cross-origin** to the remote dev API using the `.env` value, bypassing the vite proxy. They now go to the vite dev-server origin and **through** the proxy (`/api` is proxied), so cookies become first-party. Functionally expected to work, but worth a login smoke-test locally. No effect on deployed environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)